### PR TITLE
Test: Non-AppSignal change (clean)

### DIFF
--- a/productionized/pulse-fetch/shared/src/types.ts
+++ b/productionized/pulse-fetch/shared/src/types.ts
@@ -11,6 +11,7 @@ export interface ToolResponse {
     text: string;
   }>;
   isError?: boolean;
+  // Test: This should NOT trigger AppSignal CI
 }
 
 /**


### PR DESCRIPTION
## Summary
This PR tests that non-AppSignal changes only trigger the codebase-wide lint check with the new workflow configuration.

## Expected CI Checks  
Should ONLY see:
- ✅ Lint & Type Check (codebase-wide)

Should NOT see:
- ❌ AppSignal Functional Tests
- ❌ AppSignal Integration Tests
- ❌ All CI Checks Passed

## Changes
- Added test comment to pulse-fetch types.ts

🤖 Generated with [Claude Code](https://claude.ai/code)