### PR TITLE
feat: add unified 'All CI Checks Passed' workflow

### DIFF
--- a/.github/workflows/all-checks-passed.yml
+++ b/.github/workflows/all-checks-passed.yml
@@ -1,0 +1,122 @@
+name: All CI Checks Passed
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  workflow_run:
+    workflows: ['AppSignal CI', 'Lint and Format Check']
+    types: [completed]
+
+jobs:
+  all-checks-passed:
+    name: All CI Checks Passed
+    runs-on: ubuntu-latest
+    if: always()
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Check all workflow runs
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { data: checkRuns } = await github.rest.checks.listForRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: context.payload.pull_request?.head.sha || context.sha,
+            });
+
+            const { data: workflowRuns } = await github.rest.actions.listWorkflowRunsForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              head_sha: context.payload.pull_request?.head.sha || context.sha,
+              per_page: 100
+            });
+
+            // Filter out this workflow itself and any non-CI workflows
+            const relevantWorkflows = workflowRuns.workflow_runs.filter(run => 
+              run.name !== 'All CI Checks Passed' && 
+              (run.name === 'AppSignal CI' || run.name === 'Lint and Format Check')
+            );
+
+            console.log(`Found ${relevantWorkflows.length} relevant workflow runs`);
+
+            // Group by workflow name to get latest run for each
+            const latestRuns = {};
+            for (const run of relevantWorkflows) {
+              if (!latestRuns[run.name] || new Date(run.created_at) > new Date(latestRuns[run.name].created_at)) {
+                latestRuns[run.name] = run;
+              }
+            }
+
+            let allPassed = true;
+            let failureMessages = [];
+
+            // Check status of latest runs
+            for (const [workflowName, run] of Object.entries(latestRuns)) {
+              console.log(`${workflowName}: ${run.status} (${run.conclusion || 'in progress'})`);
+              
+              if (run.status === 'completed') {
+                if (run.conclusion !== 'success') {
+                  allPassed = false;
+                  failureMessages.push(`${workflowName}: ${run.conclusion}`);
+                }
+              } else {
+                // Workflow is still running
+                allPassed = false;
+                failureMessages.push(`${workflowName}: still ${run.status}`);
+              }
+            }
+
+            // Also check if required workflows have run at all
+            const expectedWorkflows = [];
+
+            // Check if this PR touches AppSignal files
+            if (context.payload.pull_request) {
+              const { data: files } = await github.rest.pulls.listFiles({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: context.payload.pull_request.number,
+              });
+              
+              const hasAppSignalChanges = files.some(file => 
+                file.filename.startsWith('experimental/appsignal/') || 
+                file.filename === '.github/workflows/appsignal-ci.yml'
+              );
+              
+              const hasLintableChanges = files.some(file => 
+                file.filename.endsWith('.ts') || 
+                file.filename.endsWith('.tsx') || 
+                file.filename.endsWith('.json') || 
+                file.filename.endsWith('.yml') || 
+                file.filename.endsWith('.yaml')
+              );
+              
+              if (hasAppSignalChanges) {
+                expectedWorkflows.push('AppSignal CI');
+              }
+              if (hasLintableChanges) {
+                expectedWorkflows.push('Lint and Format Check');
+              }
+            }
+
+            // Check if all expected workflows have run
+            for (const workflow of expectedWorkflows) {
+              if (!latestRuns[workflow]) {
+                allPassed = false;
+                failureMessages.push(`${workflow}: not run`);
+              }
+            }
+
+            if (allPassed && Object.keys(latestRuns).length > 0) {
+              console.log('✅ All CI checks passed!');
+            } else if (Object.keys(latestRuns).length === 0 && expectedWorkflows.length === 0) {
+              console.log('ℹ️  No CI checks required for this PR');
+            } else {
+              console.log('❌ One or more CI checks failed or are pending');
+              for (const msg of failureMessages) {
+                console.log(`  - ${msg}`);
+              }
+              core.setFailed('Not all CI checks passed');
+            }

--- a/.github/workflows/appsignal-ci.yml
+++ b/.github/workflows/appsignal-ci.yml
@@ -78,23 +78,3 @@ jobs:
         env:
           APPSIGNAL_API_KEY: test-api-key
           APPSIGNAL_APP_ID: test-app-id
-
-  # This job runs after all tests pass
-  all-checks-passed:
-    name: All CI Checks Passed
-    runs-on: ubuntu-latest
-    needs: [functional-tests, integration-tests]
-    if: always()
-
-    steps:
-      - name: Check if all jobs passed
-        run: |
-          if [[ "${{ needs.functional-tests.result }}" == "success" && "${{ needs.integration-tests.result }}" == "success" ]]; then
-            echo "✅ All CI checks passed!"
-            exit 0
-          else
-            echo "❌ One or more CI checks failed"
-            echo "Functional Tests: ${{ needs.functional-tests.result }}"
-            echo "Integration Tests: ${{ needs.integration-tests.result }}"
-            exit 1
-          fi

--- a/productionized/pulse-fetch/shared/src/types.ts
+++ b/productionized/pulse-fetch/shared/src/types.ts
@@ -1,5 +1,6 @@
 /**
  * Common TypeScript types for MCP servers
+ * Testing unified all checks workflow
  */
 
 /**


### PR DESCRIPTION
## Summary
- Created a new centralized workflow that runs on all PRs to verify CI status
- Dynamically detects which workflows should run based on changed files
- Removed duplicate all-checks-passed job from appsignal-ci.yml

## Details

The new `all-checks-passed.yml` workflow:
- Runs on all PR events (opened, synchronize, reopened)
- Also triggers when other workflows complete
- Uses GitHub API to check the status of all relevant workflow runs
- Dynamically determines which workflows are expected based on changed files:
  - AppSignal CI runs when `experimental/appsignal/` files or the AppSignal workflow itself change
  - Lint and Format Check runs when any `.ts`, `.tsx`, `.json`, `.yml`, or `.yaml` files change
- Provides clear status messages about which checks passed/failed/are pending
- Fails the check if any required workflows haven't run or failed

## Test plan
- [x] Create this PR with a non-AppSignal change (pulse-fetch comment)
- [ ] Verify that only Lint workflow runs (not AppSignal CI)
- [ ] Verify that "All CI Checks Passed" workflow runs and passes
- [ ] Test with an AppSignal change to ensure both workflows run
- [ ] Test with a PR that has no lintable changes

🤖 Generated with [Claude Code](https://claude.ai/code)