### PR TITLE
fix: resolve TypeScript no-explicit-any warning in AppSignal integration test

### DIFF
--- a/experimental/appsignal/tests/integration/appsignal-new-tools.integration.test.ts
+++ b/experimental/appsignal/tests/integration/appsignal-new-tools.integration.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, afterEach } from 'vitest';
 import { TestMCPClient } from '../../../../test-mcp-client/dist/index.js';
 import { createIntegrationMockAppsignalClient } from '../../shared/src/appsignal-client/appsignal-client.integration-mock.js';
 import type { IAppsignalClient } from '../../shared/src/appsignal-client/appsignal-client.js';
+import type { MockData } from '../../shared/src/appsignal-client/appsignal-client.integration-mock.js';
 import path from 'path';
 import { fileURLToPath } from 'url';
 
@@ -269,7 +270,7 @@ describe('AppSignal MCP Server New Tools Integration', () => {
  * This demonstrates how we're mocking the AppSignal API calls, not the MCP client.
  */
 async function createTestMCPClientWithMock(
-  mockAppSignalClient: IAppsignalClient & { mockData?: any }
+  mockAppSignalClient: IAppsignalClient & { mockData?: MockData }
 ): Promise<TestMCPClient> {
   // We need to pass the mock to the server somehow.
   // Since we can't inject it directly, we'll use environment variables


### PR DESCRIPTION
## Summary
- Fixed TypeScript lint error by replacing `any` type with proper `MockData` type
- Added import for `MockData` type from the integration mock module
- Ensures type safety in the `createTestMCPClientWithMock` helper function

## Test plan
- [x] Run `npm run lint` - passes without errors
- [x] Run `npm run build` in experimental/appsignal - builds successfully
- [x] All existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.ai/code)