### PR TITLE
[POC] Proper version bump to 0.1.4 - should PASS CI

### DIFF
--- a/experimental/appsignal/CHANGELOG.md
+++ b/experimental/appsignal/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.4] - 2025-06-26
+
+### Added
+- Proof of concept: Demonstrates proper CI validation passes
+
 ## [0.1.2] - 2025-06-26
 
 ### Fixed

--- a/experimental/appsignal/local/package.json
+++ b/experimental/appsignal/local/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appsignal-mcp-server",
-  "version": "0.1.2",
+  "version": "0.1.4",
   "description": "Local implementation of AppSignal MCP server",
   "main": "build/index.js",
   "type": "module",


### PR DESCRIPTION
This PR demonstrates that the CI correctly validates a properly formatted version bump.

## ✅ This PR includes:
- Version bumped from 0.1.2 to 0.1.4
- CHANGELOG.md updated with 0.1.4 entry
- Git tag created: `appsignal-mcp-server@0.1.4`

## Expected result:
The `verify-publications` check should **PASS** ✅