### PR TITLE
[POC] Missing changelog - should FAIL CI

### DIFF
--- a/experimental/appsignal/local/package.json
+++ b/experimental/appsignal/local/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appsignal-mcp-server",
-  "version": "0.1.2",
+  "version": "0.1.5",
   "description": "Local implementation of AppSignal MCP server",
   "main": "build/index.js",
   "type": "module",


### PR DESCRIPTION
This PR demonstrates that the CI correctly FAILS when the changelog is not updated.

## ❌ This PR includes:
- Version bumped from 0.1.2 to 0.1.5
- CHANGELOG.md NOT updated (intentionally)
- Git tag NOT created (intentionally)

## Expected result:
The `verify-publications` check should **FAIL** ❌