### PR TITLE
refactor: restructure README server tables and add automated README verification

### DIFF
--- a/.github/workflows/verify-mcp-server-publication.yml
+++ b/.github/workflows/verify-mcp-server-publication.yml
@@ -6,6 +6,7 @@ on:
       - 'experimental/*/local/package.json'
       - 'productionized/*/local/package.json'
       - '*/local/package.json'
+      - 'README.md'
 
 jobs:
   verify-publications:
@@ -94,6 +95,37 @@ jobs:
             fi
             
             echo "✅ CHANGELOG.md contains entry for version $CURRENT_VERSION"
+            
+            # Check if README.md was updated with the new version
+            echo "Checking if README.md was updated..."
+            
+            # Determine if this is experimental or productionized
+            if [[ "$SERVER_DIR" == experimental/* ]]; then
+              TABLE_SECTION="Experimental Servers"
+            elif [[ "$SERVER_DIR" == productionized/* ]]; then
+              TABLE_SECTION="Productionized Servers"
+            else
+              echo "⚠️  WARNING: Could not determine server type (experimental/productionized)"
+              continue
+            fi
+            
+            # Check if the server appears in README.md with the current version
+            if grep -q "| $SERVER_NAME .*| $CURRENT_VERSION |" README.md; then
+              echo "✅ README.md contains entry for $SERVER_NAME with version $CURRENT_VERSION"
+            else
+              # Check if it's marked as "Not Yet Published"
+              if grep -q "| $SERVER_NAME .*| Not Yet Published |" README.md; then
+                echo "❌ ERROR: README.md still shows 'Not Yet Published' for $SERVER_NAME"
+                echo "   Please update README.md to show version $CURRENT_VERSION"
+                VERIFICATION_FAILED=true
+                continue
+              else
+                echo "❌ ERROR: README.md does not contain correct version for $SERVER_NAME"
+                echo "   Expected to find version $CURRENT_VERSION in the $TABLE_SECTION table"
+                VERIFICATION_FAILED=true
+                continue
+              fi
+            fi
             
             # Check for git tag
             EXPECTED_TAG="${PACKAGE_NAME}@${CURRENT_VERSION}"

--- a/README.md
+++ b/README.md
@@ -15,33 +15,28 @@ You can have confidence that any Pulse-branded MCP server was built with these i
 
 ## Repository Structure
 
-- **`productionized/`**: Production-ready MCP servers (see [productionized/README.md](./productionized/README.md) for status)
-  - `pulse-fetch/`: Pull internet resources into context
-- **`experimental/`**: MCP servers in active development
+- **`productionized/`**: Production-ready MCP servers (see [productionized/README.md](./productionized/README.md))
+- **`experimental/`**: MCP servers in active development (see [experimental/README.md](./experimental/README.md))
 - **`mcp-server-template/`**: Template for creating new MCP servers
 - **`mcp-json-profiles/`**: JSON profiles for MCP configuration
 
-## Servers available
+## Servers Available
 
-### Production Servers
+### Productionized Servers
 
-#### Pulse Fetch
+These are PulseMCP-branded servers that we intend to maintain indefinitely as our own offerings.
 
-Purpose: Pull a specific resource from the open internet into context.
-
-Target audience: Agent-building frameworks (e.g. `fast-agent`, `Mastra`, `PydanticAI`, `Agno`, `OpenAI Agents SDK`) and other MCP clients that do not come with built-in "fetch" capabilities.
-
-Highlights:
-
-- Strips out HTML noise from results so as to minimize token usage during MCP Tool calls
-- Optionally saves each result as an MCP Resource so results are effectively cached
-- Offers MCP Prompts so end-users don't have to type "use the Pulse fetch server to..."
-- Option to configure Firecrawl API key to reliably work around anti-bot technology
-- Option to configure Oxylabs API key to fallback to when Firecrawl fails
+| Name | Description | Local Status | Remote Status | Target Audience | Notes |
+|------|-------------|--------------|---------------|-----------------|-------|
+| pulse-fetch | Pull internet resources into context | Not Yet Published | Not Started | Agent-building frameworks (e.g. fast-agent, Mastra, PydanticAI) and MCP clients without built-in fetch | Supports Firecrawl and Oxylabs integrations; HTML noise stripping; Resource caching |
 
 ### Experimental Servers
 
-See the [experimental/](./experimental/) directory for servers currently in development.
+These are high-quality servers that we may discontinue if the official provider creates and maintains a better MCP server.
+
+| Name | Description | Local Status | Remote Status | Target Audience | Notes |
+|------|-------------|--------------|---------------|-----------------|-------|
+| appsignal | AppSignal application performance monitoring and error tracking | 0.2.1 | Not Started | Developers using AppSignal for application monitoring | Requires AppSignal API key; NOT officially affiliated with AppSignal |
 
 ## Contributing
 

--- a/docs/PUBLISHING_SERVERS.md
+++ b/docs/PUBLISHING_SERVERS.md
@@ -88,6 +88,7 @@ When you open a PR, the "Verify MCP Server Publication Staged" GitHub Action wil
 - Ensure the git tag exists and matches the package version
 - Run tests for the modified server
 - Verify the build succeeds
+- Check that the main README.md has been updated with the new version number
 
 ### 5. Automatic Publishing
 
@@ -137,6 +138,7 @@ Before creating a PR:
 - [ ] Build succeeds (`npm run build`)
 - [ ] No sensitive information in code
 - [ ] Git tag created and pushed
+- [ ] Main README.md updated - change server's "Local Status" from "Not Yet Published" to the version number
 
 ## Troubleshooting
 
@@ -160,6 +162,19 @@ The PR verification will fail if:
 
 Ensure your git tag matches the pattern: `<package-name>@<version>`
 Example: `appsignal-mcp-server@0.1.1`
+
+### README.md Not Updated
+
+The PR verification will fail if the main README.md hasn't been updated with the new version:
+
+- For servers showing "Not Yet Published", update to the actual version number
+- The server must appear in the correct table (Experimental or Productionized)
+- The version in README.md must match the version in package.json
+
+The automated check looks for entries like:
+```
+| server-name | Description | 0.1.0 | ... |
+```
 
 ## Adding a New Server to the Publication Process
 

--- a/experimental/README.md
+++ b/experimental/README.md
@@ -1,0 +1,5 @@
+# Experimental MCP Servers
+
+This directory contains high-quality servers that we may discontinue if the official provider creates and maintains a better MCP server.
+
+For details on all experimental servers, see the [Experimental Servers section](../README.md#experimental-servers) in the main README.

--- a/productionized/README.md
+++ b/productionized/README.md
@@ -1,9 +1,5 @@
 # Productionized MCP Servers
 
-This directory contains MCP servers that have reached production quality and are ready for deployment.
+This directory contains PulseMCP-branded servers that we intend to maintain indefinitely as our own offerings.
 
-## Status Overview
-
-| Name        | Description                          | Local Status | Remote Status | Version | Notes                                       |
-| ----------- | ------------------------------------ | ------------ | ------------- | ------- | ------------------------------------------- |
-| pulse-fetch | Pull internet resources into context | In Progress  | Not Started   | -       | Supports Firecrawl and Oxylabs integrations |
+For details on all productionized servers, see the [Productionized Servers section](../README.md#productionized-servers) in the main README.


### PR DESCRIPTION
## Summary

This PR restructures the README documentation to consolidate server listings and adds automated verification to ensure README is updated when publishing servers.

## Changes

- Consolidate experimental and productionized server listings in main README.md with separate tables
- Update descriptions to clarify the distinction:
  - **Productionized**: PulseMCP-branded servers we maintain indefinitely
  - **Experimental**: High-quality servers that may be discontinued if official providers create better alternatives
- Add automated README.md version check to the `verify-mcp-server-publication.yml` workflow
- Update PUBLISHING_SERVERS.md documentation to require README updates
- Create experimental/README.md for consistency with productionized structure

## Test Plan

- [x] Verify the new table format renders correctly in README.md
- [x] Confirm CI workflow includes README verification logic
- [x] Check that subdirectory READMEs link back to main README correctly

🤖 Generated with [Claude Code](https://claude.ai/code)