### PR TITLE
docs: update README to reflect Twist MCP server v0.1.0 publication

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ These are high-quality servers that we may discontinue if the official provider 
 | Name      | Description                                                     | Local Status      | Remote Status | Target Audience                                       | Notes                                                                |
 | --------- | --------------------------------------------------------------- | ----------------- | ------------- | ----------------------------------------------------- | -------------------------------------------------------------------- |
 | appsignal | AppSignal application performance monitoring and error tracking | 0.2.1             | Not Started   | Developers using AppSignal for application monitoring | Requires AppSignal API key; NOT officially affiliated with AppSignal |
-| twist     | Twist team messaging and collaboration platform integration     | Not Yet Published | Not Started   | Teams using Twist for asynchronous communication      | Requires Twist API bearer token and workspace ID                     |
+| twist     | Twist team messaging and collaboration platform integration     | 0.1.0             | Not Started   | Teams using Twist for asynchronous communication      | Requires Twist API bearer token and workspace ID                     |
 
 ## Contributing
 


### PR DESCRIPTION
## Summary
- Updated README.md to reflect that Twist MCP server is now published at version 0.1.0
- Changed status from "Not Yet Published" to "0.1.0" in the Experimental Servers table

## Context
The Twist MCP server was recently published to npm as part of the automated CI/CD pipeline when PR #77 was merged. This PR updates the documentation to reflect the current published status.

## Changes
- Updated the Local Status column for the Twist server in README.md from "Not Yet Published" to "0.1.0"

## Test plan
- [x] Verified that the version number matches what's in the package.json files (0.1.0)
- [x] Confirmed the CHANGELOG.md already has the 0.1.0 release documented
- [x] No code changes, only documentation update

🤖 Generated with [Claude Code](https://claude.ai/code)