### PR TITLE
fix: ensure publish workflow only runs after CI checks pass

### DIFF
--- a/.github/workflows/publish-mcp-servers.yml
+++ b/.github/workflows/publish-mcp-servers.yml
@@ -1,22 +1,17 @@
 name: Publish Updated MCP Servers
 
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - 'experimental/*/local/package.json'
-      - 'productionized/*/local/package.json'
-      - '*/local/package.json'
   workflow_run:
     workflows: ['CI Build & Test Checks']
     types:
       - completed
+    branches:
+      - main
 
 jobs:
   detect-and-publish:
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'push' || (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Summary
- Remove direct push trigger from publish-mcp-servers workflow
- Rely solely on workflow_run trigger that waits for "CI Build & Test Checks" to complete successfully
- This prevents broken code from being published to npm

## Test plan
- [ ] Verify CI checks pass for this PR
- [ ] Confirm publish workflow only triggers after successful CI completion
- [ ] Test that package.json changes still trigger the workflow (after CI passes)

🤖 Generated with [Claude Code](https://claude.ai/code)