### PR TITLE
Publish appsignal-mcp-server@0.2.3 and twist-mcp-server@0.1.4

### DIFF
--- a/.claude/commands/publish_and_pr.md
+++ b/.claude/commands/publish_and_pr.md
@@ -1,0 +1,6 @@
+Goal: get a version bump for any relevant MCP servers in place, and get the PR going that we can merge after human review.
+
+I want you to:
+
+- [ ] Run the publication process for server updates ([PUBLISHING_SERVERS.md](../../docs/PUBLISHING_SERVERS.md))
+- [ ] Open a PR (or update current one for your branch) in accordance with [pr.md](./pr.md)

--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ These are high-quality servers that we may discontinue if the official provider 
 
 | Name                                   | Description                                                     | Local Status | Remote Status | Target Audience                                       | Notes                                                                |
 | -------------------------------------- | --------------------------------------------------------------- | ------------ | ------------- | ----------------------------------------------------- | -------------------------------------------------------------------- |
-| [appsignal](./experimental/appsignal/) | AppSignal application performance monitoring and error tracking | 0.2.2        | Not Started   | Developers using AppSignal for application monitoring | Requires AppSignal API key; NOT officially affiliated with AppSignal |
-| [twist](./experimental/twist/)         | Twist team messaging and collaboration platform integration     | 0.1.3        | Not Started   | Teams using Twist for asynchronous communication      | Requires Twist API bearer token and workspace ID                     |
+| [appsignal](./experimental/appsignal/) | AppSignal application performance monitoring and error tracking | 0.2.3        | Not Started   | Developers using AppSignal for application monitoring | Requires AppSignal API key; NOT officially affiliated with AppSignal |
+| [twist](./experimental/twist/)         | Twist team messaging and collaboration platform integration     | 0.1.4        | Not Started   | Teams using Twist for asynchronous communication      | Requires Twist API bearer token and workspace ID                     |
 
 ## Contributing
 

--- a/experimental/appsignal/CHANGELOG.md
+++ b/experimental/appsignal/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.3] - 2025-06-27
+
+### Fixed
+
+- Moved `bin` field from root package.json to local package.json for proper executable installation
+
 ## [0.2.2] - 2025-06-27
 
 ### Added

--- a/experimental/appsignal/local/package.json
+++ b/experimental/appsignal/local/package.json
@@ -1,9 +1,12 @@
 {
   "name": "appsignal-mcp-server",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Local implementation of AppSignal MCP server",
   "main": "build/index.js",
   "type": "module",
+  "bin": {
+    "appsignal-mcp-server": "./build/index.js"
+  },
   "scripts": {
     "build": "../node_modules/typescript/bin/tsc",
     "start": "node build/index.js",

--- a/experimental/appsignal/package-lock.json
+++ b/experimental/appsignal/package-lock.json
@@ -36,13 +36,16 @@
     },
     "local": {
       "name": "appsignal-mcp-server",
-      "version": "0.2.1",
+      "version": "0.2.3",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.4",
         "appsignal-mcp-server-shared": "file:../shared",
         "dotenv": "^16.5.0",
         "zod": "^3.24.1"
+      },
+      "bin": {
+        "appsignal-mcp-server": "build/index.js"
       },
       "devDependencies": {
         "@types/node": "^22.15.31",

--- a/experimental/appsignal/package.json
+++ b/experimental/appsignal/package.json
@@ -9,9 +9,6 @@
     "shared"
   ],
   "type": "module",
-  "bin": {
-    "appsignal-mcp-server": "./local/build/index.js"
-  },
   "scripts": {
     "install-all": "npm install && cd local && npm install && cd ../shared && npm install",
     "build": "cd shared && npm run build && cd ../local && npm run build",

--- a/experimental/twist/CHANGELOG.md
+++ b/experimental/twist/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.4] - 2025-06-27
+
+### Fixed
+
+- Moved `bin` field from root package.json to local package.json for proper executable installation
+
 ## [0.1.3] - 2025-06-27
 
 ### Added

--- a/experimental/twist/local/package.json
+++ b/experimental/twist/local/package.json
@@ -1,9 +1,12 @@
 {
   "name": "twist-mcp-server",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Local implementation of Twist MCP Server",
   "main": "build/index.js",
   "type": "module",
+  "bin": {
+    "twist-mcp-server": "./build/index.js"
+  },
   "scripts": {
     "build": "tsc && npm run build:integration",
     "build:integration": "tsc -p tsconfig.integration.json",

--- a/experimental/twist/package-lock.json
+++ b/experimental/twist/package-lock.json
@@ -12,9 +12,6 @@
         "local",
         "shared"
       ],
-      "bin": {
-        "twist-mcp-server": "local/build/index.js"
-      },
       "devDependencies": {
         "@types/node": "^24.0.0",
         "dotenv": "^16.4.5",
@@ -33,12 +30,15 @@
     },
     "local": {
       "name": "twist-mcp-server",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.4",
         "twist-mcp-server-shared": "file:../shared",
         "zod": "^3.24.1"
+      },
+      "bin": {
+        "twist-mcp-server": "build/index.js"
       },
       "devDependencies": {
         "@types/node": "^22.10.6",

--- a/experimental/twist/package.json
+++ b/experimental/twist/package.json
@@ -9,9 +9,6 @@
     "shared"
   ],
   "type": "module",
-  "bin": {
-    "twist-mcp-server": "./local/build/index.js"
-  },
   "scripts": {
     "install-all": "npm install && cd local && npm install && cd ../shared && npm install",
     "build": "cd shared && npm run build && cd ../local && npm run build",

--- a/mcp-server-template/local/package.json
+++ b/mcp-server-template/local/package.json
@@ -4,6 +4,9 @@
   "description": "Local implementation of NAME MCP server",
   "main": "build/index.js",
   "type": "module",
+  "bin": {
+    "NAME-mcp-server": "./build/index.js"
+  },
   "scripts": {
     "build": "tsc && npm run build:integration",
     "build:integration": "tsc -p tsconfig.integration.json",

--- a/mcp-server-template/package.json
+++ b/mcp-server-template/package.json
@@ -9,9 +9,6 @@
     "shared"
   ],
   "type": "module",
-  "bin": {
-    "NAME-mcp-server": "./local/build/index.js"
-  },
   "scripts": {
     "install-all": "npm install && cd local && npm install && cd ../shared && npm install",
     "build": "cd shared && npm run build && cd ../local && npm run build",


### PR DESCRIPTION
## Summary
- Fixed executable installation by moving `bin` field from root package.json to local package.json
- Bumped appsignal-mcp-server from 0.2.2 to 0.2.3
- Bumped twist-mcp-server from 0.1.3 to 0.1.4

## Changes
### AppSignal MCP Server (0.2.3)
- Moved `bin` field to local package.json for proper npx installation

### Twist MCP Server (0.1.4)
- Moved `bin` field to local package.json for proper npx installation

### Template Update
- Updated mcp-server-template to follow the same pattern for future servers

## Checklist
- [x] Version bumped in package.json files
- [x] CHANGELOG.md updated for both servers
- [x] All tests passing (builds successful)
- [x] Git tags created (appsignal-mcp-server@0.2.3, twist-mcp-server@0.1.4)
- [x] Main README.md updated with new version numbers

🤖 Generated with [Claude Code](https://claude.ai/code)