### PR TITLE
Publish twist-mcp-server@0.2.0 and appsignal-mcp-server@0.3.0

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -17,5 +17,5 @@
     "@typescript-eslint/no-unused-vars": ["error", { "argsIgnorePattern": "^_" }],
     "@typescript-eslint/no-explicit-any": "error"
   },
-  "ignorePatterns": ["node_modules", "dist", "build", "*.js", "*.mjs", "*.cjs"]
+  "ignorePatterns": ["node_modules", "dist", "build", "*.js", "*.mjs", "*.cjs", "**/local/shared"]
 }

--- a/.github/workflows/publish-mcp-servers.yml
+++ b/.github/workflows/publish-mcp-servers.yml
@@ -1,17 +1,60 @@
 name: Publish Updated MCP Servers
 
 on:
-  workflow_run:
-    workflows: ['CI Build & Test Checks']
-    types:
-      - completed
+  push:
     branches:
       - main
 
 jobs:
-  detect-and-publish:
+  wait-for-ci:
+    name: Wait for CI
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - name: Wait for CI Build & Test Checks
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const sha = context.sha;
+
+            console.log(`Waiting for CI Build & Test Checks on SHA: ${sha}`);
+
+            const maxWaitTime = 10 * 60 * 1000; // 10 minutes
+            const checkInterval = 10 * 1000; // 10 seconds
+            const startTime = Date.now();
+
+            while (Date.now() - startTime < maxWaitTime) {
+              const checkRuns = await github.rest.checks.listForRef({
+                owner,
+                repo,
+                ref: sha,
+                per_page: 100
+              });
+              
+              const ciCheck = checkRuns.data.check_runs.find(run => 
+                run.name === 'CI Build & Test Checks Passed'
+              );
+              
+              if (ciCheck && ciCheck.status === 'completed') {
+                if (ciCheck.conclusion === 'success') {
+                  console.log('✅ CI Build & Test Checks passed');
+                  return;
+                } else {
+                  core.setFailed(`CI Build & Test Checks failed with conclusion: ${ciCheck.conclusion}`);
+                  return;
+                }
+              }
+              
+              console.log(`Waiting for CI checks... (${Math.round((Date.now() - startTime) / 1000)}s elapsed)`);
+              await new Promise(resolve => setTimeout(resolve, checkInterval));
+            }
+
+            core.setFailed('Timeout waiting for CI Build & Test Checks');
+
+  detect-and-publish:
+    needs: wait-for-ci
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout code

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,9 @@ build/
 !**/prepare-publish.js
 !**/setup-dev.js
 
+# Ignore shared symlinks in local directories
+**/local/shared
+
 # Logs
 logs
 *.log

--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ These are high-quality servers that we may discontinue if the official provider 
 
 | Name                                   | Description                                                     | Local Status | Remote Status | Target Audience                                       | Notes                                                                |
 | -------------------------------------- | --------------------------------------------------------------- | ------------ | ------------- | ----------------------------------------------------- | -------------------------------------------------------------------- |
-| [appsignal](./experimental/appsignal/) | AppSignal application performance monitoring and error tracking | 0.2.4        | Not Started   | Developers using AppSignal for application monitoring | Requires AppSignal API key; NOT officially affiliated with AppSignal |
-| [twist](./experimental/twist/)         | Twist team messaging and collaboration platform integration     | 0.1.8        | Not Started   | Teams using Twist for asynchronous communication      | Requires Twist API bearer token and workspace ID                     |
+| [appsignal](./experimental/appsignal/) | AppSignal application performance monitoring and error tracking | 0.3.0        | Not Started   | Developers using AppSignal for application monitoring | Requires AppSignal API key; NOT officially affiliated with AppSignal |
+| [twist](./experimental/twist/)         | Twist team messaging and collaboration platform integration     | 0.2.0        | Not Started   | Teams using Twist for asynchronous communication      | Requires Twist API bearer token and workspace ID                     |
 
 ## Contributing
 

--- a/experimental/appsignal/CHANGELOG.md
+++ b/experimental/appsignal/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - 2025-06-27
+
+### Fixed
+
+- Fixed npm publish build issues by updating prepare-publish script to properly install and build shared dependencies
+- Removed prebuild scripts that were causing TypeScript compilation errors in CI environment
+
 ## [0.2.4] - 2025-06-27
 
 ### Fixed

--- a/experimental/appsignal/local/package.json
+++ b/experimental/appsignal/local/package.json
@@ -14,7 +14,6 @@
     "dev": "tsx src/index.ts",
     "dev:integration": "tsx src/index.integration-with-mock.ts",
     "predev": "cd ../shared && npm run build && cd ../local && node setup-dev.js",
-    "prebuild": "cd ../shared && npm run build && cd ../local && node setup-dev.js",
     "prepublishOnly": "npm run build && node prepare-publish.js && node ../scripts/prepare-npm-readme.js",
     "stage-publish": "npm version"
   },

--- a/experimental/appsignal/local/package.json
+++ b/experimental/appsignal/local/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appsignal-mcp-server",
-  "version": "0.2.4",
+  "version": "0.3.0",
   "description": "Local implementation of AppSignal MCP server",
   "main": "build/index.js",
   "type": "module",

--- a/experimental/appsignal/local/prepare-publish.js
+++ b/experimental/appsignal/local/prepare-publish.js
@@ -2,11 +2,22 @@
 import { cp, rm } from 'fs/promises';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
+import { execSync } from 'child_process';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
 async function prepare() {
   console.log('Preparing for publish...');
+
+  // First, ensure shared directory is built
+  const sharedDir = join(__dirname, '../shared');
+  console.log('Building shared directory...');
+  try {
+    execSync('npm install && npm run build', { cwd: sharedDir, stdio: 'inherit' });
+  } catch (e) {
+    console.error('Failed to build shared directory:', e.message);
+    process.exit(1);
+  }
 
   // Clean up any existing shared directory
   try {

--- a/experimental/appsignal/package-lock.json
+++ b/experimental/appsignal/package-lock.json
@@ -36,7 +36,7 @@
     },
     "local": {
       "name": "appsignal-mcp-server",
-      "version": "0.2.3",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.4",

--- a/experimental/twist/CHANGELOG.md
+++ b/experimental/twist/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2025-06-27
+
+### Fixed
+
+- Fixed npm publish build issues by updating prepare-publish script to properly install and build shared dependencies
+- Removed prebuild scripts that were causing TypeScript compilation errors in CI environment
+
 ## [0.1.8] - 2025-06-27
 
 ### Fixed

--- a/experimental/twist/local/package.json
+++ b/experimental/twist/local/package.json
@@ -1,6 +1,6 @@
 {
   "name": "twist-mcp-server",
-  "version": "0.1.8",
+  "version": "0.2.0",
   "description": "Local implementation of Twist MCP Server",
   "main": "build/index.js",
   "type": "module",

--- a/experimental/twist/local/package.json
+++ b/experimental/twist/local/package.json
@@ -19,7 +19,6 @@
     "start": "node build/index.js",
     "dev": "tsx src/index.ts",
     "predev": "cd ../shared && npm run build && cd ../local && node setup-dev.js",
-    "prebuild": "cd ../shared && npm run build && cd ../local && node setup-dev.js",
     "lint": "eslint . --ext .ts,.tsx",
     "lint:fix": "eslint . --ext .ts,.tsx --fix",
     "format": "prettier --write .",

--- a/experimental/twist/local/prepare-publish.js
+++ b/experimental/twist/local/prepare-publish.js
@@ -2,11 +2,22 @@
 import { cp, rm } from 'fs/promises';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
+import { execSync } from 'child_process';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
 async function prepare() {
   console.log('Preparing for publish...');
+
+  // First, ensure shared directory is built
+  const sharedDir = join(__dirname, '../shared');
+  console.log('Building shared directory...');
+  try {
+    execSync('npm install && npm run build', { cwd: sharedDir, stdio: 'inherit' });
+  } catch (e) {
+    console.error('Failed to build shared directory:', e.message);
+    process.exit(1);
+  }
 
   // Clean up any existing shared directory
   try {

--- a/experimental/twist/package-lock.json
+++ b/experimental/twist/package-lock.json
@@ -30,7 +30,7 @@
     },
     "local": {
       "name": "twist-mcp-server",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.4",

--- a/experimental/twist/package-lock.json
+++ b/experimental/twist/package-lock.json
@@ -30,7 +30,7 @@
     },
     "local": {
       "name": "twist-mcp-server",
-      "version": "0.1.9",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.4",

--- a/mcp-server-template/local/package.json
+++ b/mcp-server-template/local/package.json
@@ -19,7 +19,6 @@
     "start": "node build/index.js",
     "dev": "tsx src/index.ts",
     "predev": "cd ../shared && npm run build && cd ../local && node setup-dev.js",
-    "prebuild": "cd ../shared && npm run build && cd ../local && node setup-dev.js",
     "prepublishOnly": "npm run build && node prepare-publish.js",
     "lint": "eslint . --ext .ts,.tsx",
     "lint:fix": "eslint . --ext .ts,.tsx --fix",

--- a/mcp-server-template/local/prepare-publish.js
+++ b/mcp-server-template/local/prepare-publish.js
@@ -2,11 +2,22 @@
 import { cp, rm } from 'fs/promises';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
+import { execSync } from 'child_process';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
 async function prepare() {
   console.log('Preparing for publish...');
+
+  // First, ensure shared directory is built
+  const sharedDir = join(__dirname, '../shared');
+  console.log('Building shared directory...');
+  try {
+    execSync('npm install && npm run build', { cwd: sharedDir, stdio: 'inherit' });
+  } catch (e) {
+    console.error('Failed to build shared directory:', e.message);
+    process.exit(1);
+  }
 
   // Clean up any existing shared directory
   try {


### PR DESCRIPTION
Publishing minor version bumps for both Twist and AppSignal MCP servers.

## Changes

### twist-mcp-server@0.2.0
- Fixed npm publish build issues by updating prepare-publish script to properly install and build shared dependencies
- Removed prebuild scripts that were causing TypeScript compilation errors in CI environment

### appsignal-mcp-server@0.3.0
- Fixed npm publish build issues by updating prepare-publish script to properly install and build shared dependencies
- Removed prebuild scripts that were causing TypeScript compilation errors in CI environment

## Checklist
- [x] Version bumped in package.json files
- [x] CHANGELOG.md updated for both servers
- [x] All tests passing
- [x] Git tags created (twist-mcp-server@0.2.0, appsignal-mcp-server@0.3.0)
- [x] README.md updated with new version numbers

These version bumps are necessary to get the servers properly published with the build fixes from PR #89.

🤖 Generated with [Claude Code](https://claude.ai/code)