### PR TITLE
fix: reorder prepare-publish.js build steps to fix TypeScript import errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ These are high-quality servers that we may discontinue if the official provider 
 
 | Name                                   | Description                                                     | Local Status | Remote Status | Target Audience                                       | Notes                                                                |
 | -------------------------------------- | --------------------------------------------------------------- | ------------ | ------------- | ----------------------------------------------------- | -------------------------------------------------------------------- |
-| [appsignal](./experimental/appsignal/) | AppSignal application performance monitoring and error tracking | 0.2.7        | Not Started   | Developers using AppSignal for application monitoring | Requires AppSignal API key; NOT officially affiliated with AppSignal |
-| [twist](./experimental/twist/)         | Twist team messaging and collaboration platform integration     | 0.1.10       | Not Started   | Teams using Twist for asynchronous communication      | Requires Twist API bearer token and workspace ID                     |
+| [appsignal](./experimental/appsignal/) | AppSignal application performance monitoring and error tracking | 0.2.8        | Not Started   | Developers using AppSignal for application monitoring | Requires AppSignal API key; NOT officially affiliated with AppSignal |
+| [twist](./experimental/twist/)         | Twist team messaging and collaboration platform integration     | 0.1.11       | Not Started   | Teams using Twist for asynchronous communication      | Requires Twist API bearer token and workspace ID                     |
 
 ## Contributing
 

--- a/experimental/appsignal/CHANGELOG.md
+++ b/experimental/appsignal/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.8] - 2025-06-27
+
+### Fixed
+
+- Fixed npm publish TypeScript build errors by reordering prepare-publish.js steps
+- Build shared directory first before building local to ensure imports resolve correctly
+
 ## [0.2.7] - 2025-06-27
 
 ### Fixed

--- a/experimental/appsignal/local/package.json
+++ b/experimental/appsignal/local/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appsignal-mcp-server",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "description": "Local implementation of AppSignal MCP server",
   "main": "build/index.js",
   "type": "module",

--- a/experimental/appsignal/package-lock.json
+++ b/experimental/appsignal/package-lock.json
@@ -36,7 +36,7 @@
     },
     "local": {
       "name": "appsignal-mcp-server",
-      "version": "0.2.7",
+      "version": "0.2.8",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.4",

--- a/experimental/appsignal/package-lock.json
+++ b/experimental/appsignal/package-lock.json
@@ -36,7 +36,7 @@
     },
     "local": {
       "name": "appsignal-mcp-server",
-      "version": "0.2.6",
+      "version": "0.2.7",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.4",

--- a/experimental/twist/CHANGELOG.md
+++ b/experimental/twist/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.11] - 2025-06-27
+
+### Fixed
+
+- Fixed npm publish TypeScript build errors by reordering prepare-publish.js steps
+- Build shared directory first before building local to ensure imports resolve correctly
+
 ## [0.1.10] - 2025-06-27
 
 ### Fixed

--- a/experimental/twist/local/package.json
+++ b/experimental/twist/local/package.json
@@ -1,6 +1,6 @@
 {
   "name": "twist-mcp-server",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "description": "Local implementation of Twist MCP Server",
   "main": "build/index.js",
   "type": "module",

--- a/experimental/twist/package-lock.json
+++ b/experimental/twist/package-lock.json
@@ -30,7 +30,7 @@
     },
     "local": {
       "name": "twist-mcp-server",
-      "version": "0.1.9",
+      "version": "0.1.11",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.4",

--- a/mcp-server-template/README.md
+++ b/mcp-server-template/README.md
@@ -278,12 +278,14 @@ During development, the `local` package imports from the `shared` package using 
 When publishing to npm, we need to ensure the shared code is included without workspace dependencies:
 
 1. The `prepublishOnly` script runs automatically before `npm publish`
-2. It runs `tsc` directly (not `npm run build`) to avoid triggering `prebuild`
-3. Then it runs `prepare-publish.js` which:
-   - Installs and builds the shared directory
-   - Copies the built `shared/dist` files into `local/shared`
-4. The package is published with all necessary files included
-5. No bundler or extra dependencies needed!
+2. It runs `prepare-publish.js` which:
+   - Installs TypeScript temporarily (for CI environments)
+   - Builds the shared directory first
+   - Creates a symlink for building (using setup-dev.js)
+   - Builds the local package with all imports resolved
+   - Replaces the symlink with actual files for publishing
+3. The package is published with all necessary files included
+4. No bundler or extra dependencies needed!
 
 #### Script Execution Flow
 
@@ -297,10 +299,11 @@ When publishing to npm, we need to ensure the shared code is included without wo
 - `npm publish` → triggers `prepublishOnly` → runs `prepare-publish.js` → publishes
 - `prepare-publish.js` handles everything:
   1. Installs TypeScript temporarily (for CI environments)
-  2. Builds local package
-  3. Builds shared package
-  4. Copies shared files into local/shared
-  5. Package is ready for publishing
+  2. Builds shared package first
+  3. Creates symlink using setup-dev.js
+  4. Builds local package (with imports resolved)
+  5. Replaces symlink with actual shared files
+  6. Package is ready for publishing
 
 ### Important Files
 


### PR DESCRIPTION
## Summary

This PR fixes the npm publish failures that were occurring due to TypeScript import resolution errors during the prepare-publish process.

## Problem

The prepare-publish.js script was trying to build the local package before setting up the shared directory, causing TypeScript compilation to fail with errors like:
- `Cannot find module '../shared/index.js'`
- `Cannot find module 'appsignal-mcp-server-shared'`

## Solution

Reordered the build steps in prepare-publish.js:
1. Build shared directory first
2. Create symlink using setup-dev.js (for import resolution)
3. Build local package (now imports can resolve)
4. Replace symlink with actual files for publishing

## Changes

- Updated prepare-publish.js in:
  - experimental/appsignal/local/
  - experimental/twist/local/
  - mcp-server-template/local/
- Updated documentation in mcp-server-template/README.md

## Testing

Tested locally by running `node prepare-publish.js` in the appsignal directory - build completed successfully.

## Checklist

- [x] Fixed the TypeScript import errors
- [x] Applied fix to all affected servers
- [x] Updated documentation
- [x] Tested locally