### PR TITLE
docs: clean up duplicate npm publish fix entries from changelogs

### DIFF
--- a/experimental/appsignal/CHANGELOG.md
+++ b/experimental/appsignal/CHANGELOG.md
@@ -16,34 +16,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.2.7] - 2025-06-27
 
-### Fixed
-
-- Improved npm publish process consistency with other servers
-- Updated prepare-publish.js to handle TypeScript installation properly
-
 ## [0.2.6] - 2025-06-27
-
-### Fixed
-
-- Completely resolved npm publish build issues by moving all build logic into prepare-publish.js
-- prepare-publish.js now installs TypeScript temporarily during publish to avoid dependency issues
-- Removed build step from CI publish workflow to let prepublishOnly handle everything
 
 ## [0.2.5] - 2025-06-27
 
-### Fixed
-
-- Fixed npm publish build issues by updating prepare-publish script to properly install and build shared dependencies
-- Modified prepublishOnly script to avoid prebuild script during npm publish
-
 ## [0.2.4] - 2025-06-27
-
-### Fixed
-
-- Resolved npm publish issues with workspace dependencies
-  - Fixed "invalid or damaged lockfile" error when running via npx
-  - Implemented build-time copying approach to handle shared workspace code
-  - No bundler dependencies required
 
 ## [0.2.3] - 2025-06-27
 

--- a/experimental/twist/CHANGELOG.md
+++ b/experimental/twist/CHANGELOG.md
@@ -16,26 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.1.10] - 2025-06-27
 
-### Fixed
-
-- Improved npm publish process consistency with other servers
-- Updated prepare-publish.js to handle TypeScript installation properly
-
 ## [0.1.9] - 2025-06-27
 
-### Fixed
-
-- Fixed npm publish build issues by updating prepare-publish script to properly install and build shared dependencies
-- Modified prepublishOnly script to avoid prebuild script during npm publish
-
 ## [0.1.8] - 2025-06-27
-
-### Fixed
-
-- Resolved npm publish issues with workspace dependencies
-  - Fixed "invalid or damaged lockfile" error when running via npx
-  - Implemented build-time copying approach to handle shared workspace code
-  - No bundler dependencies required
 
 ## [0.1.4] - 2025-06-27
 


### PR DESCRIPTION
## Summary

This PR cleans up the CHANGELOGs for both appsignal and twist servers by removing duplicate npm publish fix entries that were accumulated across multiple versions while debugging the issue.

## Changes

- **appsignal/CHANGELOG.md**: Removed duplicate npm publish fix descriptions from versions 0.2.4 through 0.2.7
- **twist/CHANGELOG.md**: Removed duplicate npm publish fix descriptions from versions 0.1.8 through 0.1.10

## Rationale

The npm publish issue was debugged across multiple iterations, resulting in similar fix descriptions in multiple versions. Since the final fix is documented in the latest versions (0.2.8 for appsignal and 0.1.11 for twist), the intermediate attempts add noise without value.

Version headers are preserved for historical reference, showing that multiple patch versions were released on the same day while resolving the issue.

## Result

The changelogs now clearly show:
- The final, working fix in the latest versions
- Clean version history without redundant information
- Other legitimate changes in those versions remain documented