### PR TITLE
fix: add missing graphql dependencies to appsignal local package

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ These are high-quality servers that we may discontinue if the official provider 
 
 | Name                                   | Description                                                     | Local Status | Remote Status | Target Audience                                       | Notes                                                                |
 | -------------------------------------- | --------------------------------------------------------------- | ------------ | ------------- | ----------------------------------------------------- | -------------------------------------------------------------------- |
-| [appsignal](./experimental/appsignal/) | AppSignal application performance monitoring and error tracking | 0.2.8        | Not Started   | Developers using AppSignal for application monitoring | Requires AppSignal API key; NOT officially affiliated with AppSignal |
+| [appsignal](./experimental/appsignal/) | AppSignal application performance monitoring and error tracking | 0.2.9        | Not Started   | Developers using AppSignal for application monitoring | Requires AppSignal API key; NOT officially affiliated with AppSignal |
 | [twist](./experimental/twist/)         | Twist team messaging and collaboration platform integration     | 0.1.11       | Not Started   | Teams using Twist for asynchronous communication      | Requires Twist API bearer token and workspace ID                     |
 
 ## Contributing

--- a/experimental/appsignal/CHANGELOG.md
+++ b/experimental/appsignal/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.9] - 2025-06-27
+
+### Fixed
+
+- Added missing graphql and graphql-request dependencies to local package.json
+- This fixes runtime errors when running the server via npx or npm install
+
 ## [0.2.8] - 2025-06-27
 
 ### Fixed

--- a/experimental/appsignal/local/package.json
+++ b/experimental/appsignal/local/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appsignal-mcp-server",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "description": "Local implementation of AppSignal MCP server",
   "main": "build/index.js",
   "type": "module",
@@ -26,6 +26,8 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.4",
     "dotenv": "^16.5.0",
+    "graphql": "^16.11.0",
+    "graphql-request": "^7.2.0",
     "zod": "^3.24.1"
   },
   "devDependencies": {

--- a/experimental/appsignal/package-lock.json
+++ b/experimental/appsignal/package-lock.json
@@ -36,11 +36,13 @@
     },
     "local": {
       "name": "appsignal-mcp-server",
-      "version": "0.2.8",
+      "version": "0.2.9",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.4",
         "dotenv": "^16.5.0",
+        "graphql": "^16.11.0",
+        "graphql-request": "^7.2.0",
         "zod": "^3.24.1"
       },
       "bin": {
@@ -58,6 +60,17 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "local/node_modules/graphql-request": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/graphql-request/-/graphql-request-7.2.0.tgz",
+      "integrity": "sha512-0GR7eQHBFYz372u9lxS16cOtEekFlZYB2qOyq8wDvzRmdRSJ0mgUVX1tzNcIzk3G+4NY+mGtSz411wZdeDF/+A==",
+      "dependencies": {
+        "@graphql-typed-document-node/core": "^3.2.0"
+      },
+      "peerDependencies": {
+        "graphql": "14 - 16"
       }
     },
     "local/node_modules/undici-types": {


### PR DESCRIPTION
## Summary

This PR fixes a critical runtime error in the appsignal-mcp-server package where graphql dependencies were missing from the local package.json.

## Problem

When users install appsignal-mcp-server via npm or npx, they encounter runtime errors because:
- The shared code imports `graphql-request` and depends on `graphql`
- These dependencies were only in the shared package.json, not in the local (published) package.json
- npm doesn't install transitive workspace dependencies when installing a published package

## Solution

Added the missing dependencies to the local package.json:
- `graphql: ^16.11.0`
- `graphql-request: ^7.2.0`

## Testing

1. Tested local installation with `npm install ../experimental/appsignal/local`
2. Verified dependencies are present in the installed package
3. Confirmed the package can be packed and distributed correctly

## Version Bump

Bumped to version 0.2.9 as this is a bug fix.

🤖 Generated with [Claude Code](https://claude.ai/code)