### PR TITLE
Publish twist-mcp-server@0.1.12

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,6 +130,41 @@ npm run test:manual
 4. Replace "NAME" and "DESCRIPTION" placeholders
 5. Implement your resources and tools in src/index.ts
 
+## Workspace Dependencies and Import Paths
+
+**CRITICAL: DO NOT modify workspace import paths without understanding the publish workflow.**
+
+Some MCP servers (like `experimental/twist/` and `experimental/appsignal/`) use a specialized workspace setup with carefully designed import paths that support both development and publishing:
+
+### Development vs. Publishing Setup
+
+These servers have a `local/` and `shared/` structure where:
+
+- **Development**: `local/setup-dev.js` creates symlinks for development (e.g., `local/shared` → `../shared/dist`)
+- **Publishing**: `local/prepare-publish.js` copies built files for npm publishing
+- **Imports**: Use relative paths like `'../shared/index.js'` that work in both scenarios
+
+### Import Path Rules
+
+**✅ CORRECT**: 
+```typescript
+import { createMCPServer } from '../shared/index.js';
+```
+
+**❌ WRONG** - Breaks publish workflow:
+```typescript
+import { createMCPServer } from 'twist-mcp-server-shared';  // Package name
+import { createMCPServer } from '../shared/dist/index.js';  // Direct dist path
+```
+
+### If You Encounter Import Errors
+
+1. **First**, run the setup script: `node setup-dev.js` in the `local/` directory
+2. **Then**, ensure the shared module is built: `npm run build` in the `shared/` directory
+3. **Never** change import paths to use package names or direct dist paths
+
+This setup was established in commits #89, #91, #92 to resolve TypeScript build and npm publish issues. Modifying these import paths will break the publishing workflow.
+
 ## Additional Documentation
 
 Each server directory contains its own CLAUDE.md with specific implementation details.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,15 +146,17 @@ These servers have a `local/` and `shared/` structure where:
 
 ### Import Path Rules
 
-**✅ CORRECT**: 
+**✅ CORRECT**:
+
 ```typescript
 import { createMCPServer } from '../shared/index.js';
 ```
 
 **❌ WRONG** - Breaks publish workflow:
+
 ```typescript
-import { createMCPServer } from 'twist-mcp-server-shared';  // Package name
-import { createMCPServer } from '../shared/dist/index.js';  // Direct dist path
+import { createMCPServer } from 'twist-mcp-server-shared'; // Package name
+import { createMCPServer } from '../shared/dist/index.js'; // Direct dist path
 ```
 
 ### If You Encounter Import Errors

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ These are high-quality servers that we may discontinue if the official provider 
 | Name                                   | Description                                                     | Local Status | Remote Status | Target Audience                                       | Notes                                                                |
 | -------------------------------------- | --------------------------------------------------------------- | ------------ | ------------- | ----------------------------------------------------- | -------------------------------------------------------------------- |
 | [appsignal](./experimental/appsignal/) | AppSignal application performance monitoring and error tracking | 0.2.9        | Not Started   | Developers using AppSignal for application monitoring | Requires AppSignal API key; NOT officially affiliated with AppSignal |
-| [twist](./experimental/twist/)         | Twist team messaging and collaboration platform integration     | 0.1.11       | Not Started   | Teams using Twist for asynchronous communication      | Requires Twist API bearer token and workspace ID                     |
+| [twist](./experimental/twist/)         | Twist team messaging and collaboration platform integration     | 0.1.12       | Not Started   | Teams using Twist for asynchronous communication      | Requires Twist API bearer token and workspace ID                     |
 
 ## Contributing
 

--- a/experimental/twist/CHANGELOG.md
+++ b/experimental/twist/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.12] - 2025-06-27
+
+### Fixed
+
+- Fixed missing first message in thread responses by including thread content as the first chronological message
+- Enhanced Thread interface to include content, attachments, actions, and reactions fields
+- Updated get_thread tool to properly combine thread content with comments in chronological order
+- Fixed message count display to reflect all messages including the original thread content
+
 ## [0.1.11] - 2025-06-27
 
 ### Fixed

--- a/experimental/twist/local/package.json
+++ b/experimental/twist/local/package.json
@@ -1,6 +1,6 @@
 {
   "name": "twist-mcp-server",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "description": "Local implementation of Twist MCP Server",
   "main": "build/index.js",
   "type": "module",

--- a/experimental/twist/package-lock.json
+++ b/experimental/twist/package-lock.json
@@ -30,7 +30,7 @@
     },
     "local": {
       "name": "twist-mcp-server",
-      "version": "0.1.11",
+      "version": "0.1.12",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.4",
@@ -2449,7 +2449,7 @@
       },
       "devDependencies": {
         "@types/node": "^22.10.6",
-        "typescript": "^5.7.3"
+        "typescript": "^5.8.3"
       }
     },
     "shared/node_modules/@types/node": {

--- a/experimental/twist/shared/package.json
+++ b/experimental/twist/shared/package.json
@@ -17,7 +17,7 @@
   },
   "devDependencies": {
     "@types/node": "^22.10.6",
-    "typescript": "^5.7.3"
+    "typescript": "^5.8.3"
   },
   "keywords": [],
   "author": "PulseMCP",

--- a/experimental/twist/shared/src/server.ts
+++ b/experimental/twist/shared/src/server.ts
@@ -43,6 +43,10 @@ export interface Thread {
   last_updated_ts?: number;
   archived?: boolean;
   closed?: boolean;
+  content?: string;
+  attachments?: Attachment[];
+  actions?: ActionButton[];
+  reactions?: Record<string, number[]>;
 }
 
 export interface ThreadWithMessages extends Thread {

--- a/experimental/twist/shared/src/tools/get-thread.ts
+++ b/experimental/twist/shared/src/tools/get-thread.ts
@@ -88,7 +88,7 @@ Use cases:
 
         // Combine thread content (first message) with comments
         const allMessages = [];
-        
+
         // Add thread content as the first message if it exists
         if (thread.content) {
           allMessages.push({
@@ -104,7 +104,7 @@ Use cases:
             system_message: null,
           });
         }
-        
+
         // Add all comment messages
         if (thread.messages && thread.messages.length > 0) {
           allMessages.push(...thread.messages);

--- a/experimental/twist/shared/src/tools/get-thread.ts
+++ b/experimental/twist/shared/src/tools/get-thread.ts
@@ -86,18 +86,42 @@ Use cases:
       try {
         const thread = await client.getThread(thread_id);
 
+        // Combine thread content (first message) with comments
+        const allMessages = [];
+        
+        // Add thread content as the first message if it exists
+        if (thread.content) {
+          allMessages.push({
+            id: `thread-${thread.id}`,
+            thread_id: thread.id,
+            content: thread.content,
+            creator: thread.creator,
+            creator_name: thread.creator_name,
+            posted_ts: thread.posted_ts,
+            actions: thread.actions,
+            attachments: thread.attachments,
+            reactions: thread.reactions,
+            system_message: null,
+          });
+        }
+        
+        // Add all comment messages
+        if (thread.messages && thread.messages.length > 0) {
+          allMessages.push(...thread.messages);
+        }
+
         let response = `Thread: "${thread.title}"
 ID: ${thread.id}
 Channel ID: ${thread.channel_id}
 Created: ${thread.posted_ts ? new Date(thread.posted_ts * 1000).toLocaleString() : 'Unknown'}
 Status: ${thread.archived ? 'Archived' : 'Active'}
 
-Messages (${thread.messages?.length || 0} total):
+Messages (${allMessages.length} total):
 `;
 
-        if (thread.messages && thread.messages.length > 0) {
-          // Sort messages by posted time
-          const sortedMessages = thread.messages.sort(
+        if (allMessages.length > 0) {
+          // Sort all messages by posted time
+          const sortedMessages = allMessages.sort(
             (a, b) => (a.posted_ts || 0) - (b.posted_ts || 0)
           );
 
@@ -207,8 +231,8 @@ Messages (${thread.messages?.length || 0} total):
               : '';
 
           response = response.replace(
-            `Messages (${thread.messages?.length || 0} total):`,
-            `Messages (${thread.messages?.length || 0} total)${paginationInfo}:`
+            `Messages (${allMessages.length} total):`,
+            `Messages (${allMessages.length} total)${paginationInfo}:`
           );
           response += messageList;
         } else {

--- a/experimental/twist/tests/functional/tools.test.ts
+++ b/experimental/twist/tests/functional/tools.test.ts
@@ -117,18 +117,20 @@ describe('Twist Tools', () => {
       const result = await tool.handler({ thread_id: 'th_001' });
 
       const responseText = result.content[0].text;
-      
+
       // Should have 2 total messages (thread content + comment)
       expect(responseText).toContain('Messages (2 total):');
-      
+
       // Should include the original thread content as the first message
-      expect(responseText).toContain('This is the original thread content that starts the discussion');
+      expect(responseText).toContain(
+        'This is the original thread content that starts the discussion'
+      );
       expect(responseText).toContain('Thread Creator:');
-      
+
       // Should also include the comment message
       expect(responseText).toContain('Test message');
       expect(responseText).toContain('Test User:');
-      
+
       // Thread content should appear before the comment (chronologically first)
       const threadContentIndex = responseText.indexOf('This is the original thread content');
       const commentIndex = responseText.indexOf('Test message');
@@ -154,7 +156,7 @@ describe('Twist Tools', () => {
 
       // Should have 1 total message (just the thread content)
       expect(responseText).toContain('Messages (1 total):');
-      
+
       // Should include the thread content
       expect(responseText).toContain('This thread has only the initial content, no comments yet');
       expect(responseText).toContain('Thread Creator:');

--- a/experimental/twist/tests/functional/tools.test.ts
+++ b/experimental/twist/tests/functional/tools.test.ts
@@ -107,8 +107,57 @@ describe('Twist Tools', () => {
         type: 'text',
         text: expect.stringContaining('Thread: "Test Thread"'),
       });
-      expect(result.content[0].text).toContain('Messages (1 total):');
+      expect(result.content[0].text).toContain('Messages (2 total):');
       expect(result.content[0].text).toContain('Test message');
+    });
+
+    it('should include thread content as the first message', async () => {
+      const tool = getThreadTool(mockServer, () => mockClient);
+
+      const result = await tool.handler({ thread_id: 'th_001' });
+
+      const responseText = result.content[0].text;
+      
+      // Should have 2 total messages (thread content + comment)
+      expect(responseText).toContain('Messages (2 total):');
+      
+      // Should include the original thread content as the first message
+      expect(responseText).toContain('This is the original thread content that starts the discussion');
+      expect(responseText).toContain('Thread Creator:');
+      
+      // Should also include the comment message
+      expect(responseText).toContain('Test message');
+      expect(responseText).toContain('Test User:');
+      
+      // Thread content should appear before the comment (chronologically first)
+      const threadContentIndex = responseText.indexOf('This is the original thread content');
+      const commentIndex = responseText.indexOf('Test message');
+      expect(threadContentIndex).toBeLessThan(commentIndex);
+    });
+
+    it('should handle thread with content but no comments', async () => {
+      mockClient.getThread = vi.fn().mockResolvedValue({
+        id: 'th_001',
+        title: 'Thread with just content',
+        channel_id: 'ch_123',
+        workspace_id: '228287',
+        creator: 'user_123',
+        creator_name: 'Thread Creator',
+        posted_ts: 1234567890,
+        content: 'This thread has only the initial content, no comments yet',
+        messages: [], // No comments
+      });
+      const tool = getThreadTool(mockServer, () => mockClient);
+
+      const result = await tool.handler({ thread_id: 'th_001' });
+      const responseText = result.content[0].text;
+
+      // Should have 1 total message (just the thread content)
+      expect(responseText).toContain('Messages (1 total):');
+      
+      // Should include the thread content
+      expect(responseText).toContain('This thread has only the initial content, no comments yet');
+      expect(responseText).toContain('Thread Creator:');
     });
 
     it('should handle thread with no messages', async () => {

--- a/experimental/twist/tests/mocks/twist-client.functional-mock.ts
+++ b/experimental/twist/tests/mocks/twist-client.functional-mock.ts
@@ -57,9 +57,11 @@ export function createFunctionalMockTwistClient(): ITwistClient {
           channel_id: 'ch_123',
           workspace_id: '228287',
           creator: 'user_123',
+          creator_name: 'Thread Creator',
           posted_ts: 1234567890,
           last_updated_ts: 1234567890,
           archived: false,
+          content: 'This is the original thread content that starts the discussion',
           messages: [
             {
               id: 'msg_001',


### PR DESCRIPTION
Publishing Twist MCP server version 0.1.12

## Changes

### Fixed
- Fixed missing first message in thread responses by including thread content as the first chronological message
- Enhanced Thread interface to include content, attachments, actions, and reactions fields  
- Updated get_thread tool to properly combine thread content with comments in chronological order
- Fixed message count display to reflect all messages including the original thread content

### Additional Improvements
- Added comprehensive workspace dependency documentation to root CLAUDE.md to prevent future import path issues
- Added test coverage for thread content inclusion functionality

## Problem Solved

Previously, when calling `get_thread`, only the comments were returned from the `/comments/get` endpoint, missing the original thread content which is stored in the thread object itself. This meant users were missing the first message that started the thread.

Now the tool properly combines:
1. Thread content (the original message) 
2. All comments chronologically ordered

## Testing

- ✅ Manual test confirmed fix works with production thread ID 7057859 (now shows 2 messages instead of 1)
- ✅ All functional tests pass (20/20)
- ✅ All integration tests pass (18/18)  
- ✅ Added specific test coverage for thread content inclusion

## Checklist

- [x] Version bumped in package.json (0.1.11 → 0.1.12)
- [x] CHANGELOG.md updated with new version section
- [x] All tests passing
- [x] Git tag created (twist-mcp-server@0.1.12)
- [x] Main README.md updated with new version number
- [x] No sensitive information in code
- [x] Import paths preserved for publish workflow