### PR TITLE
fix: bump pulse-fetch version to 0.0.2 to trigger npm publication

### DIFF
--- a/productionized/pulse-fetch/CHANGELOG.md
+++ b/productionized/pulse-fetch/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to the Pulse Fetch MCP server will be documented in this fil
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.2] - 2025-06-29
+
+### Changed
+
+- Package name changed from `pulse-fetch` to `@pulsemcp/pulse-fetch` for npm scoped publishing
+- Updated bin entry to match new scoped package name
+
 ## [0.0.1] - 2025-06-29
 
 ### Added

--- a/productionized/pulse-fetch/local/package.json
+++ b/productionized/pulse-fetch/local/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/pulse-fetch",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Local implementation of pulse-fetch MCP server",
   "main": "build/index.js",
   "type": "module",


### PR DESCRIPTION
## Summary

- Bump pulse-fetch version from 0.0.1 to 0.0.2 to trigger npm publication
- Add changelog entry documenting the package name change

## Problem

The pulse-fetch server didn't publish to npm in CI after the initial implementation PR #101 was merged. Investigation revealed that the publication workflow only publishes packages when it detects a version change between commits.

Even though the package name changed from `pulse-fetch` to `@pulsemcp/pulse-fetch`, the version remained `0.0.1` in both the previous and current commit, so the publication workflow correctly skipped publishing.

## Solution

- Bump version to `0.0.2` in `productionized/pulse-fetch/local/package.json`
- Add corresponding changelog entry explaining the package name change

## Test plan

- [x] Version bump triggers publication workflow detection logic
- [x] Pre-commit hooks pass (linting, formatting)
- [ ] CI pipeline publishes @pulsemcp/pulse-fetch@0.0.2 to npm after merge

🤖 Generated with [Claude Code](https://claude.ai/code)