### PR TITLE
Publish @pulsemcp/pulse-fetch@0.0.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ You can have confidence that any Pulse-branded MCP server was built with these n
 
 These are PulseMCP-branded servers that we intend to maintain indefinitely as our own offerings.
 
-| Name                                         | Description                          | Local Status      | Remote Status | Target Audience                                                                                        | Notes                                                                               |
-| -------------------------------------------- | ------------------------------------ | ----------------- | ------------- | ------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------- |
-| [pulse-fetch](./productionized/pulse-fetch/) | Pull internet resources into context | Not Yet Published | Not Started   | Agent-building frameworks (e.g. fast-agent, Mastra, PydanticAI) and MCP clients without built-in fetch | Supports Firecrawl and Oxylabs integrations; HTML noise stripping; Resource caching |
+| Name                                         | Description                          | Local Status | Remote Status | Target Audience                                                                                        | Notes                                                                                  |
+| -------------------------------------------- | ------------------------------------ | ------------ | ------------- | ------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------- |
+| [pulse-fetch](./productionized/pulse-fetch/) | Pull internet resources into context | 0.0.4        | Not Started   | Agent-building frameworks (e.g. fast-agent, Mastra, PydanticAI) and MCP clients without built-in fetch | Supports Firecrawl and BrightData integrations; HTML noise stripping; Resource caching |
 
 ### Experimental Servers
 

--- a/productionized/pulse-fetch/CHANGELOG.md
+++ b/productionized/pulse-fetch/CHANGELOG.md
@@ -7,11 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.0.4] - 2025-06-29
 
+### Added
+
+- Native scraping client class following MCP client architecture patterns
+- Comprehensive manual test suite with individual client tests
+- Class-based scraping client architecture (NativeScrapingClient, FirecrawlScrapingClient, BrightDataScrapingClient)
+- Enhanced manual testing with one-liner commands for each scraping mode
+- Detailed content analysis and response statistics in manual tests
+- README documentation for manual test usage and debugging
+
+### Changed
+
+- Refactored scraping clients from functions to class-based implementations
+- Improved manual test output with better formatting and analysis
+- Enhanced error detection and success/failure reporting in tests
+
 ### Fixed
 
 - Fixed missing README concatenation for npm publication: added `scripts/prepare-npm-readme.js` to properly merge main README with local configuration
 - Local README now contains only local-specific configuration, allowing proper concatenation during publish
 - Published npm package will now display full documentation instead of minimal local README
+- Fixed import paths and TypeScript compilation issues in manual tests
+- Improved error handling in scraping client classes
 
 ## [0.0.3] - 2025-06-29
 

--- a/productionized/pulse-fetch/CLAUDE.md
+++ b/productionized/pulse-fetch/CLAUDE.md
@@ -117,6 +117,4 @@ Key insights gathered during implementation and CI troubleshooting:
 
 - **Publication Process**: Follow the detailed guidelines in `/docs/PUBLISHING_SERVERS.md` for version bumping, changelog updates, and automated publishing
 - **Merge Conflict Resolution**: When rebasing onto main during publication, combine changelog entries from both branches preserving the intent of all changes (e.g., merge README fixes with feature additions)
-- **Vitest Configuration**: Always exclude manual test directories (`**/manual/**`) from Vitest configuration to prevent CI failures - manual tests use `node --import tsx` and don't contain Vitest test suites
 - **CI Monitoring**: Use `gh run list --branch <branch-name>` to check workflow runs when `gh pr checks` doesn't show results - CI may complete successfully even if checks aren't visible in PR view
-- **Manual Test Verification**: Always test manual test suites locally with both success and failure cases to ensure they correctly detect issues and avoid false positives

--- a/productionized/pulse-fetch/CLAUDE.md
+++ b/productionized/pulse-fetch/CLAUDE.md
@@ -115,7 +115,8 @@ Key insights gathered during implementation and CI troubleshooting:
 
 ### Publication and CI Process
 
-- **Version Management**: Use `npm run stage-publish patch` from the local directory to properly bump versions and create git tags
+- **Publication Process**: Follow the detailed guidelines in `/docs/PUBLISHING_SERVERS.md` for version bumping, changelog updates, and automated publishing
+- **Merge Conflict Resolution**: When rebasing onto main during publication, combine changelog entries from both branches preserving the intent of all changes (e.g., merge README fixes with feature additions)
+- **Vitest Configuration**: Always exclude manual test directories (`**/manual/**`) from Vitest configuration to prevent CI failures - manual tests use `node --import tsx` and don't contain Vitest test suites
 - **CI Monitoring**: Use `gh run list --branch <branch-name>` to check workflow runs when `gh pr checks` doesn't show results - CI may complete successfully even if checks aren't visible in PR view
-- **Pre-commit Hook Issues**: If lint-staged fails with module import errors, run `rm -rf node_modules package-lock.json && npm install` from repository root to fix dependency resolution
 - **Manual Test Verification**: Always test manual test suites locally with both success and failure cases to ensure they correctly detect issues and avoid false positives

--- a/productionized/pulse-fetch/CLAUDE.md
+++ b/productionized/pulse-fetch/CLAUDE.md
@@ -105,3 +105,17 @@ Key insights gathered during implementation and CI troubleshooting:
 - **Error Handling**: Use try-catch blocks without error parameters (`catch { }`) to avoid unused variable warnings
 - **Content Processing**: Implement truncation and pagination at the tool level for better user experience
 - **Service Validation**: Validate environment variables at startup and log available services for debugging
+
+### Manual Testing and Client Architecture
+
+- **Class-Based Client Design**: Following the twist-client pattern, create client classes with consistent interfaces (`scrape(url, options)`) rather than standalone functions
+- **Manual Test Suite Strategy**: Create individual test files for each client with one-liner commands for easy debugging - essential for testing external API integrations
+- **Success/Failure Detection**: Use specific success indicators in test output (e.g., "✅ [Client] scraping successful") to properly distinguish between actual failures and expected error content
+- **Test Output Formatting**: Include content analysis, response statistics, and character distribution analysis to help understand how different scraping services behave with various content types
+
+### Publication and CI Process
+
+- **Version Management**: Use `npm run stage-publish patch` from the local directory to properly bump versions and create git tags
+- **CI Monitoring**: Use `gh run list --branch <branch-name>` to check workflow runs when `gh pr checks` doesn't show results - CI may complete successfully even if checks aren't visible in PR view
+- **Pre-commit Hook Issues**: If lint-staged fails with module import errors, run `rm -rf node_modules package-lock.json && npm install` from repository root to fix dependency resolution
+- **Manual Test Verification**: Always test manual test suites locally with both success and failure cases to ensure they correctly detect issues and avoid false positives

--- a/productionized/pulse-fetch/local/package-lock.json
+++ b/productionized/pulse-fetch/local/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pulse-fetch-local",
-  "version": "1.0.0",
+  "version": "0.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pulse-fetch-local",
-      "version": "1.0.0",
+      "version": "0.0.4",
       "license": "ISC",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.11.2",

--- a/productionized/pulse-fetch/package-lock.json
+++ b/productionized/pulse-fetch/package-lock.json
@@ -15,7 +15,7 @@
       "devDependencies": {
         "@types/node": "^24.0.0",
         "@vitest/ui": "^3.2.3",
-        "dotenv": "^16.4.5",
+        "dotenv": "^16.6.1",
         "vitest": "^3.2.3"
       },
       "optionalDependencies": {
@@ -31,7 +31,7 @@
     },
     "local": {
       "name": "@pulsemcp/pulse-fetch",
-      "version": "0.0.1",
+      "version": "0.0.4",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.4",
@@ -41,27 +41,10 @@
         "pulse-fetch": "build/index.js"
       },
       "devDependencies": {
-        "@types/node": "^22.10.6",
+        "@types/node": "^24.0.0",
         "tsx": "^4.19.4",
         "typescript": "^5.7.3"
       }
-    },
-    "local/node_modules/@types/node": {
-      "version": "22.15.34",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.34.tgz",
-      "integrity": "sha512-8Y6E5WUupYy1Dd0II32BsWAx5MWdcnRd8L84Oys3veg1YrYtNtzgO4CFhiBg6MDSjk7Ay36HYOnU7/tuOzIzcw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~6.21.0"
-      }
-    },
-    "local/node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.25.5",
@@ -1216,7 +1199,6 @@
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
       "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
       "dev": true,
-      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
       },
@@ -2718,26 +2700,9 @@
         "zod": "^3.24.1"
       },
       "devDependencies": {
-        "@types/node": "^22.10.6",
+        "@types/node": "^24.0.0",
         "typescript": "^5.7.3"
       }
-    },
-    "shared/node_modules/@types/node": {
-      "version": "22.15.34",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.34.tgz",
-      "integrity": "sha512-8Y6E5WUupYy1Dd0II32BsWAx5MWdcnRd8L84Oys3veg1YrYtNtzgO4CFhiBg6MDSjk7Ay36HYOnU7/tuOzIzcw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~6.21.0"
-      }
-    },
-    "shared/node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
-      "license": "MIT"
     }
   }
 }

--- a/productionized/pulse-fetch/package.json
+++ b/productionized/pulse-fetch/package.json
@@ -34,7 +34,7 @@
   "devDependencies": {
     "@types/node": "^24.0.0",
     "@vitest/ui": "^3.2.3",
-    "dotenv": "^16.4.5",
+    "dotenv": "^16.6.1",
     "vitest": "^3.2.3"
   },
   "optionalDependencies": {

--- a/productionized/pulse-fetch/shared/src/scraping-client/brightdata-scrape-client.ts
+++ b/productionized/pulse-fetch/shared/src/scraping-client/brightdata-scrape-client.ts
@@ -1,0 +1,34 @@
+/**
+ * BrightData scraping client implementation
+ * Provides anti-bot bypass capabilities using BrightData Web Unlocker
+ */
+
+export interface IBrightDataScrapingClient {
+  scrape(url: string, options?: BrightDataScrapingOptions): Promise<BrightDataScrapingResult>;
+}
+
+export interface BrightDataScrapingOptions {
+  zone?: string;
+  format?: 'raw' | 'json';
+  country?: string;
+  render?: boolean;
+  waitFor?: number;
+}
+
+export interface BrightDataScrapingResult {
+  success: boolean;
+  data?: string;
+  error?: string;
+}
+
+export class BrightDataScrapingClient implements IBrightDataScrapingClient {
+  constructor(private bearerToken: string) {}
+
+  async scrape(
+    url: string,
+    options: BrightDataScrapingOptions = {}
+  ): Promise<BrightDataScrapingResult> {
+    const { scrapeWithBrightData } = await import('./lib/brightdata-scrape.js');
+    return scrapeWithBrightData(this.bearerToken, url, options as Record<string, unknown>);
+  }
+}

--- a/productionized/pulse-fetch/shared/src/scraping-client/firecrawl-scrape-client.ts
+++ b/productionized/pulse-fetch/shared/src/scraping-client/firecrawl-scrape-client.ts
@@ -1,0 +1,44 @@
+/**
+ * Firecrawl scraping client implementation
+ * Provides enhanced content extraction using Firecrawl API
+ */
+
+export interface IFirecrawlScrapingClient {
+  scrape(url: string, options?: FirecrawlScrapingOptions): Promise<FirecrawlScrapingResult>;
+}
+
+export interface FirecrawlScrapingOptions {
+  formats?: Array<'markdown' | 'html'>;
+  onlyMainContent?: boolean;
+  waitFor?: number;
+  timeout?: number;
+  extract?: {
+    schema?: Record<string, unknown>;
+    systemPrompt?: string;
+    prompt?: string;
+  };
+  removeBase64Images?: boolean;
+}
+
+export interface FirecrawlScrapingResult {
+  success: boolean;
+  data?: {
+    content: string;
+    markdown: string;
+    html: string;
+    metadata: Record<string, unknown>;
+  };
+  error?: string;
+}
+
+export class FirecrawlScrapingClient implements IFirecrawlScrapingClient {
+  constructor(private apiKey: string) {}
+
+  async scrape(
+    url: string,
+    options: FirecrawlScrapingOptions = {}
+  ): Promise<FirecrawlScrapingResult> {
+    const { scrapeWithFirecrawl } = await import('./lib/firecrawl-scrape.js');
+    return scrapeWithFirecrawl(this.apiKey, url, options as Record<string, unknown>);
+  }
+}

--- a/productionized/pulse-fetch/shared/src/scraping-client/native-scrape-client.ts
+++ b/productionized/pulse-fetch/shared/src/scraping-client/native-scrape-client.ts
@@ -1,0 +1,95 @@
+/**
+ * Native scraping client implementation
+ * Provides basic HTTP fetching without external services
+ */
+
+export interface INativeScrapingClient {
+  scrape(url: string, options?: NativeScrapingOptions): Promise<NativeScrapingResult>;
+}
+
+export interface NativeScrapingOptions {
+  timeout?: number;
+  headers?: Record<string, string>;
+  method?: 'GET' | 'POST';
+  body?: string;
+}
+
+export interface NativeScrapingResult {
+  success: boolean;
+  data?: string;
+  error?: string;
+  statusCode?: number;
+  headers?: Record<string, string>;
+  contentType?: string;
+  contentLength?: number;
+}
+
+export class NativeScrapingClient implements INativeScrapingClient {
+  private defaultHeaders: Record<string, string> = {
+    'User-Agent': 'Mozilla/5.0 (compatible; PulseMCP/1.0; +https://pulsemcp.com)',
+    Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+    'Accept-Language': 'en-US,en;q=0.5',
+    'Accept-Encoding': 'gzip, deflate',
+    'Cache-Control': 'no-cache',
+  };
+
+  async scrape(url: string, options: NativeScrapingOptions = {}): Promise<NativeScrapingResult> {
+    try {
+      const controller = new AbortController();
+      const timeoutId = options.timeout
+        ? setTimeout(() => controller.abort(), options.timeout)
+        : null;
+
+      const response = await fetch(url, {
+        method: options.method || 'GET',
+        headers: {
+          ...this.defaultHeaders,
+          ...options.headers,
+        },
+        body: options.body,
+        signal: controller.signal,
+      });
+
+      if (timeoutId) {
+        clearTimeout(timeoutId);
+      }
+
+      const responseHeaders: Record<string, string> = {};
+      response.headers.forEach((value, key) => {
+        responseHeaders[key] = value;
+      });
+
+      if (!response.ok) {
+        return {
+          success: false,
+          error: `HTTP ${response.status}: ${response.statusText}`,
+          statusCode: response.status,
+          headers: responseHeaders,
+        };
+      }
+
+      const data = await response.text();
+
+      return {
+        success: true,
+        data,
+        statusCode: response.status,
+        headers: responseHeaders,
+        contentType: response.headers.get('content-type') || undefined,
+        contentLength: data.length,
+      };
+    } catch (error) {
+      if (error instanceof Error && error.name === 'AbortError') {
+        return {
+          success: false,
+          error: 'Request timeout',
+        };
+      }
+
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'Unknown error',
+      };
+    }
+  }
+}

--- a/productionized/pulse-fetch/shared/src/scraping-client/scraping-client.ts
+++ b/productionized/pulse-fetch/shared/src/scraping-client/scraping-client.ts
@@ -1,0 +1,28 @@
+/**
+ * Main scraping client exports
+ * Re-exports all scraping client interfaces and implementations
+ */
+
+// Native scraping client
+export type {
+  INativeScrapingClient,
+  NativeScrapingOptions,
+  NativeScrapingResult,
+} from './native-scrape-client.js';
+export { NativeScrapingClient } from './native-scrape-client.js';
+
+// Firecrawl scraping client
+export type {
+  IFirecrawlScrapingClient,
+  FirecrawlScrapingOptions,
+  FirecrawlScrapingResult,
+} from './firecrawl-scrape-client.js';
+export { FirecrawlScrapingClient } from './firecrawl-scrape-client.js';
+
+// BrightData scraping client
+export type {
+  IBrightDataScrapingClient,
+  BrightDataScrapingOptions,
+  BrightDataScrapingResult,
+} from './brightdata-scrape-client.js';
+export { BrightDataScrapingClient } from './brightdata-scrape-client.js';

--- a/productionized/pulse-fetch/tests/manual/README.md
+++ b/productionized/pulse-fetch/tests/manual/README.md
@@ -1,0 +1,124 @@
+# Manual Test Suite for Pulse-Fetch Scraping Clients
+
+This directory contains manual tests for the three scraping client classes: Native, Firecrawl, and BrightData.
+
+## Prerequisites
+
+1. **Environment Variables**: Set up your `.env` file in the pulse-fetch root directory:
+
+   ```bash
+   FIRECRAWL_API_KEY=fc-your-api-key-here
+   BRIGHTDATA_API_KEY=Bearer your-bearer-token-here
+   ```
+
+2. **Dependencies**: Ensure you've built the project:
+   ```bash
+   npm run build
+   ```
+
+## Individual Client Tests
+
+All commands should be run from the `productionized/pulse-fetch` directory.
+
+### Native Scraping Client
+
+```bash
+node --import tsx tests/manual/native-scraping.manual.test.ts <url>
+
+# Examples:
+node --import tsx tests/manual/native-scraping.manual.test.ts https://example.com
+node --import tsx tests/manual/native-scraping.manual.test.ts https://pulsemcp.com
+node --import tsx tests/manual/native-scraping.manual.test.ts https://www.yelp.com/biz/dolly-san-francisco
+```
+
+**Features tested:**
+
+- Basic HTTP fetching with timeout support
+- Response headers and content analysis
+- Content type detection and basic HTML parsing
+
+### Firecrawl Scraping Client
+
+```bash
+node --import tsx tests/manual/firecrawl-scraping.manual.test.ts <url>
+
+# Examples:
+node --import tsx tests/manual/firecrawl-scraping.manual.test.ts https://espn.com
+node --import tsx tests/manual/firecrawl-scraping.manual.test.ts https://news.ycombinator.com
+```
+
+**Features tested:**
+
+- Enhanced content extraction with markdown output
+- Metadata extraction (title, description, etc.)
+- Credit usage tracking
+- Main content filtering
+
+### BrightData Scraping Client
+
+```bash
+node --import tsx tests/manual/brightdata-scraping.manual.test.ts <url>
+
+# Examples:
+node --import tsx tests/manual/brightdata-scraping.manual.test.ts https://yelp.com
+node --import tsx tests/manual/brightdata-scraping.manual.test.ts https://protected-site.com
+```
+
+**Features tested:**
+
+- Anti-bot bypass capabilities
+- Raw HTML extraction
+- Content statistics and analysis
+- Character distribution analysis
+
+## Comprehensive Test Suite
+
+Run all clients against predefined test URLs:
+
+```bash
+node --import tsx tests/manual/comprehensive-suite.manual.test.ts
+```
+
+This will test:
+
+- **pulsemcp.com** (expected: native)
+- **espn.com** (expected: firecrawl)
+- **yelp.com** (expected: brightdata)
+- **example.com** (expected: native)
+- **news.ycombinator.com** (expected: native, firecrawl)
+
+The suite includes:
+
+- Rate limiting between requests (2-second delays)
+- Success/failure tracking for each client
+- Comprehensive statistics and summary report
+- Error handling and logging
+
+## Client Architecture
+
+Each test uses the corresponding scraping client class:
+
+- `NativeScrapingClient` - Direct HTTP fetching with fetch API
+- `FirecrawlScrapingClient` - Wrapper around Firecrawl API
+- `BrightDataScrapingClient` - Wrapper around BrightData Web Unlocker API
+
+All clients follow the same interface pattern with:
+
+- Constructor accepting API credentials
+- `scrape(url, options)` method returning standardized result objects
+- Proper error handling and type safety
+
+## Debugging Tips
+
+1. **Import Errors**: Make sure you're running from the correct directory (`productionized/pulse-fetch`)
+2. **API Key Issues**: Check your `.env` file format and ensure keys are properly set
+3. **Build Issues**: Run `npm run build` if you see module resolution errors
+4. **Rate Limiting**: The comprehensive suite includes delays, but individual tests don't - be mindful of API rate limits
+
+## Expected Behavior
+
+- **Native Client**: Should work on most simple sites, may fail on heavily protected or JavaScript-dependent sites
+- **Firecrawl Client**: Excellent for content extraction, provides clean markdown, may be blocked by some anti-bot measures
+- **BrightData Client**: Should work on protected sites, provides raw HTML, best for bypassing bot detection
+
+Each client provides detailed output including content previews, metadata, and analysis to help you understand how different scraping approaches behave with various types of websites.

--- a/productionized/pulse-fetch/tests/manual/brightdata-scraping.manual.test.ts
+++ b/productionized/pulse-fetch/tests/manual/brightdata-scraping.manual.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Manual test for BrightData scraping client
+ *
+ * One-liner command (run from pulse-fetch directory):
+ * node --import tsx tests/manual/brightdata-scraping.manual.test.ts https://example.com
+ */
+
+import 'dotenv/config';
+import { BrightDataScrapingClient } from '../../shared/src/scraping-client/brightdata-scrape-client.js';
+
+async function testBrightDataScrapingClient(url: string) {
+  console.log(`🌟 Testing BrightData Scraping Client for: ${url}`);
+  console.log('='.repeat(60));
+
+  const bearerToken = process.env.BRIGHTDATA_API_KEY;
+  if (!bearerToken) {
+    console.log('❌ BRIGHTDATA_API_KEY not found in environment variables');
+    console.log('   Please set BRIGHTDATA_API_KEY in your .env file');
+    console.log('   Format: Bearer <your-token>');
+    return;
+  }
+
+  console.log(`🔑 Using API key: ${bearerToken.slice(0, 15)}...`);
+
+  const client = new BrightDataScrapingClient(bearerToken);
+
+  try {
+    const result = await client.scrape(url, {
+      zone: 'mcp_server_unlocker',
+      format: 'raw',
+    });
+
+    if (!result.success) {
+      console.log(`❌ BrightData scraping failed: ${result.error}`);
+      return;
+    }
+
+    if (!result.data) {
+      console.log('❌ BrightData returned no data');
+      return;
+    }
+
+    console.log('✅ BrightData scraping successful');
+    console.log(`📝 Content length: ${result.data.length} characters`);
+
+    // Show content preview
+    console.log('\n📖 Content preview:');
+    console.log('-'.repeat(40));
+    console.log(result.data.slice(0, 500) + (result.data.length > 500 ? '...' : ''));
+    console.log('-'.repeat(40));
+
+    // Basic content analysis
+    const hasTitle = /<title[^>]*>([^<]+)<\/title>/i.test(result.data);
+    const hasJavaScript = /<script[^>]*>/i.test(result.data);
+    const hasStructuredContent = /<(article|main|section|div)[^>]*>/i.test(result.data);
+    const isHtml = result.data.trim().startsWith('<');
+    const isJson = result.data.trim().startsWith('{') || result.data.trim().startsWith('[');
+
+    console.log('\n🔍 Content analysis:');
+    console.log(`  - Is HTML: ${isHtml ? '✅' : '❌'}`);
+    console.log(`  - Is JSON: ${isJson ? '✅' : '❌'}`);
+    console.log(`  - Has title tag: ${hasTitle ? '✅' : '❌'}`);
+    console.log(`  - Has JavaScript: ${hasJavaScript ? '✅' : '❌'}`);
+    console.log(`  - Has structured content: ${hasStructuredContent ? '✅' : '❌'}`);
+
+    // Character distribution analysis
+    const totalChars = result.data.length;
+    const htmlChars = (result.data.match(/</g) || []).length;
+    const textDensity = (((totalChars - htmlChars * 10) / totalChars) * 100).toFixed(1);
+
+    console.log('\n📊 Content statistics:');
+    console.log(`  - Total characters: ${totalChars.toLocaleString()}`);
+    console.log(`  - HTML tags: ${htmlChars}`);
+    console.log(`  - Text density: ${textDensity}%`);
+  } catch (error) {
+    console.log(
+      `❌ BrightData scraping client error: ${error instanceof Error ? error.message : 'Unknown error'}`
+    );
+  }
+}
+
+// CLI usage
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const url = process.argv[2];
+  if (!url) {
+    console.log('Usage: node --import tsx tests/manual/brightdata-scraping.manual.test.ts <url>');
+    console.log(
+      'Example: node --import tsx tests/manual/brightdata-scraping.manual.test.ts https://yelp.com'
+    );
+    console.log('\nRun from the pulse-fetch directory:');
+    console.log(
+      'cd productionized/pulse-fetch && node --import tsx tests/manual/brightdata-scraping.manual.test.ts <url>'
+    );
+    process.exit(1);
+  }
+
+  testBrightDataScrapingClient(url).catch(console.error);
+}
+
+export { testBrightDataScrapingClient };

--- a/productionized/pulse-fetch/tests/manual/comprehensive-suite.manual.test.ts
+++ b/productionized/pulse-fetch/tests/manual/comprehensive-suite.manual.test.ts
@@ -1,0 +1,251 @@
+/**
+ * Comprehensive manual test suite for all scraping client classes
+ *
+ * Tests predefined URLs with expected scraping methods:
+ * - Native: pulsemcp.com (simple static site)
+ * - Firecrawl: espn.com (content-rich site)
+ * - BrightData: yelp.com (protected content)
+ *
+ * One-liner command (run from pulse-fetch directory):
+ * node --import tsx tests/manual/comprehensive-suite.manual.test.ts
+ */
+
+import 'dotenv/config';
+import { testNativeScrapingClient } from './native-scraping.manual.test.js';
+import { testFirecrawlScrapingClient } from './firecrawl-scraping.manual.test.js';
+import { testBrightDataScrapingClient } from './brightdata-scraping.manual.test.js';
+
+interface TestCase {
+  url: string;
+  description: string;
+  expectedMethods: string[];
+  notes?: string;
+}
+
+const TEST_CASES: TestCase[] = [
+  {
+    url: 'https://example.com',
+    description: 'Example.com - Basic test page',
+    expectedMethods: ['native'],
+    notes: 'Simple HTML page for basic functionality testing',
+  },
+  {
+    url: 'https://pulsemcp.com',
+    description: 'PulseMCP Homepage - Simple static site',
+    expectedMethods: ['native'],
+    notes: 'Should work well with native client due to simple structure',
+  },
+  {
+    url: 'https://espn.com',
+    description: 'ESPN - Content-rich news site',
+    expectedMethods: ['firecrawl'],
+    notes: 'Complex site with ads/navigation - Firecrawl should extract main content cleanly',
+  },
+  {
+    url: 'https://news.ycombinator.com',
+    description: 'Hacker News - Minimal dynamic content',
+    expectedMethods: ['native', 'firecrawl'],
+    notes: 'Should work with native, Firecrawl might provide better structure',
+  },
+  {
+    url: 'https://httpstat.us/403',
+    description: 'HTTP 403 Status Test - Simulated protected content',
+    expectedMethods: ['brightdata'],
+    notes: 'Native should fail with 403, Firecrawl may handle as success, BrightData should work',
+  },
+];
+
+async function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function captureTestOutput(
+  testFn: () => Promise<void>
+): Promise<{ success: boolean; error?: string }> {
+  try {
+    // Capture console output
+    const originalLog = console.log;
+    let output = '';
+    console.log = (...args) => {
+      output += args.join(' ') + '\n';
+      originalLog(...args);
+    };
+
+    await testFn();
+
+    // Restore console.log
+    console.log = originalLog;
+
+    // Check if test was successful (look for success indicators)
+    // A test is successful if it shows "✅ [Client] scraping successful"
+    // even if it also shows ❌ in content analysis or other parts
+    const hasSuccess =
+      output.includes('✅') &&
+      (output.includes('scraping successful') ||
+        output.includes('Native scraping successful') ||
+        output.includes('Firecrawl scraping successful') ||
+        output.includes('BrightData scraping successful'));
+    return { success: hasSuccess };
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'Unknown error',
+    };
+  }
+}
+
+async function runComprehensiveClientTests() {
+  console.log('🚀 Starting Comprehensive Pulse-Fetch Client Test Suite');
+  console.log('='.repeat(80));
+
+  const results: Array<{
+    testCase: TestCase;
+    nativeSuccess: boolean;
+    firecrawlSuccess: boolean;
+    brightdataSuccess: boolean;
+    errors: string[];
+  }> = [];
+
+  for (let i = 0; i < TEST_CASES.length; i++) {
+    const testCase = TEST_CASES[i];
+    console.log(`\n📋 Test ${i + 1}/${TEST_CASES.length}: ${testCase.description}`);
+    console.log(`🔗 URL: ${testCase.url}`);
+    console.log(`📝 Expected methods: ${testCase.expectedMethods.join(', ')}`);
+    if (testCase.notes) {
+      console.log(`💡 Notes: ${testCase.notes}`);
+    }
+    console.log('-'.repeat(60));
+
+    const result = {
+      testCase,
+      nativeSuccess: false,
+      firecrawlSuccess: false,
+      brightdataSuccess: false,
+      errors: [] as string[],
+    };
+
+    // Test Native Scraping Client
+    console.log('\n🔍 Testing Native Scraping Client...');
+    const nativeResult = await captureTestOutput(() => testNativeScrapingClient(testCase.url));
+    result.nativeSuccess = nativeResult.success;
+    if (!nativeResult.success && nativeResult.error) {
+      result.errors.push(`Native: ${nativeResult.error}`);
+    }
+
+    await sleep(2000); // Rate limiting
+
+    // Test Firecrawl Client (if API key available)
+    if (process.env.FIRECRAWL_API_KEY) {
+      console.log('\n🔥 Testing Firecrawl Scraping Client...');
+      const firecrawlResult = await captureTestOutput(() =>
+        testFirecrawlScrapingClient(testCase.url)
+      );
+      result.firecrawlSuccess = firecrawlResult.success;
+      if (!firecrawlResult.success && firecrawlResult.error) {
+        result.errors.push(`Firecrawl: ${firecrawlResult.error}`);
+      }
+      await sleep(2000); // Rate limiting
+    } else {
+      console.log('\n⚠️  Skipping Firecrawl (no API key)');
+    }
+
+    // Test BrightData Client (if API key available)
+    if (process.env.BRIGHTDATA_API_KEY) {
+      console.log('\n🌟 Testing BrightData Scraping Client...');
+      const brightdataResult = await captureTestOutput(() =>
+        testBrightDataScrapingClient(testCase.url)
+      );
+      result.brightdataSuccess = brightdataResult.success;
+      if (!brightdataResult.success && brightdataResult.error) {
+        result.errors.push(`BrightData: ${brightdataResult.error}`);
+      }
+      await sleep(2000); // Rate limiting
+    } else {
+      console.log('\n⚠️  Skipping BrightData (no API key)');
+    }
+
+    results.push(result);
+    console.log('\n' + '='.repeat(80));
+  }
+
+  // Summary Report
+  console.log('\n📊 CLIENT TEST SUMMARY REPORT');
+  console.log('='.repeat(80));
+
+  for (let i = 0; i < results.length; i++) {
+    const result = results[i];
+    console.log(`\n${i + 1}. ${result.testCase.description}`);
+    console.log(`   URL: ${result.testCase.url}`);
+    console.log(`   Native Client:     ${result.nativeSuccess ? '✅' : '❌'}`);
+    console.log(`   Firecrawl Client:  ${result.firecrawlSuccess ? '✅' : '❌'}`);
+    console.log(`   BrightData Client: ${result.brightdataSuccess ? '✅' : '❌'}`);
+
+    if (result.errors.length > 0) {
+      console.log(`   Errors: ${result.errors.join(', ')}`);
+    }
+
+    // Check if expected methods worked
+    const expectedWorking = result.testCase.expectedMethods.some((method) => {
+      switch (method) {
+        case 'native':
+          return result.nativeSuccess;
+        case 'firecrawl':
+          return result.firecrawlSuccess;
+        case 'brightdata':
+          return result.brightdataSuccess;
+        default:
+          return false;
+      }
+    });
+
+    console.log(`   Expected: ${expectedWorking ? '✅ PASS' : '❌ FAIL'}`);
+  }
+
+  // Overall statistics
+  const totalTests = results.length;
+  const nativeSuccesses = results.filter((r) => r.nativeSuccess).length;
+  const firecrawlSuccesses = results.filter((r) => r.firecrawlSuccess).length;
+  const brightdataSuccesses = results.filter((r) => r.brightdataSuccess).length;
+  const expectedPasses = results.filter((r) =>
+    r.testCase.expectedMethods.some((method) => {
+      switch (method) {
+        case 'native':
+          return r.nativeSuccess;
+        case 'firecrawl':
+          return r.firecrawlSuccess;
+        case 'brightdata':
+          return r.brightdataSuccess;
+        default:
+          return false;
+      }
+    })
+  ).length;
+
+  console.log('\n📈 OVERALL CLIENT STATISTICS');
+  console.log('-'.repeat(40));
+  console.log(`Total test cases: ${totalTests}`);
+  console.log(
+    `Native client success rate: ${nativeSuccesses}/${totalTests} (${Math.round((nativeSuccesses / totalTests) * 100)}%)`
+  );
+  console.log(
+    `Firecrawl client success rate: ${firecrawlSuccesses}/${totalTests} (${Math.round((firecrawlSuccesses / totalTests) * 100)}%)`
+  );
+  console.log(
+    `BrightData client success rate: ${brightdataSuccesses}/${totalTests} (${Math.round((brightdataSuccesses / totalTests) * 100)}%)`
+  );
+  console.log(
+    `Expected methods working: ${expectedPasses}/${totalTests} (${Math.round((expectedPasses / totalTests) * 100)}%)`
+  );
+
+  console.log('\n✅ Comprehensive client test suite completed!');
+}
+
+// CLI usage
+if (import.meta.url === `file://${process.argv[1]}`) {
+  console.log(
+    'Usage: cd productionized/pulse-fetch && node --import tsx tests/manual/comprehensive-suite.manual.test.ts'
+  );
+  runComprehensiveClientTests().catch(console.error);
+}
+
+export { runComprehensiveClientTests, TEST_CASES };

--- a/productionized/pulse-fetch/tests/manual/firecrawl-scraping.manual.test.ts
+++ b/productionized/pulse-fetch/tests/manual/firecrawl-scraping.manual.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Manual test for Firecrawl scraping client
+ *
+ * One-liner command (run from pulse-fetch directory):
+ * node --import tsx tests/manual/firecrawl-scraping.manual.test.ts https://example.com
+ */
+
+import 'dotenv/config';
+import { FirecrawlScrapingClient } from '../../shared/src/scraping-client/firecrawl-scrape-client.js';
+
+async function testFirecrawlScrapingClient(url: string) {
+  console.log(`🔥 Testing Firecrawl Scraping Client for: ${url}`);
+  console.log('='.repeat(60));
+
+  const apiKey = process.env.FIRECRAWL_API_KEY;
+  if (!apiKey) {
+    console.log('❌ FIRECRAWL_API_KEY not found in environment variables');
+    console.log('   Please set FIRECRAWL_API_KEY in your .env file');
+    return;
+  }
+
+  console.log(`🔑 Using API key: ${apiKey.slice(0, 10)}...`);
+
+  const client = new FirecrawlScrapingClient(apiKey);
+
+  try {
+    const result = await client.scrape(url, {
+      onlyMainContent: true,
+      formats: ['markdown', 'html'],
+    });
+
+    if (!result.success) {
+      console.log(`❌ Firecrawl scraping failed: ${result.error}`);
+      return;
+    }
+
+    if (!result.data) {
+      console.log('❌ Firecrawl returned no data');
+      return;
+    }
+
+    console.log('✅ Firecrawl scraping successful');
+
+    // Show content lengths
+    console.log(`📝 Markdown length: ${result.data.markdown?.length || 0} characters`);
+    console.log(`📝 HTML length: ${result.data.html?.length || 0} characters`);
+    console.log(`📝 Raw content length: ${result.data.content?.length || 0} characters`);
+    console.log(`📊 Metadata keys: ${Object.keys(result.data.metadata || {}).join(', ')}`);
+
+    // Show markdown preview
+    if (result.data.markdown) {
+      console.log('\n📖 Markdown preview:');
+      console.log('-'.repeat(40));
+      console.log(
+        result.data.markdown.slice(0, 500) + (result.data.markdown.length > 500 ? '...' : '')
+      );
+      console.log('-'.repeat(40));
+    }
+
+    // Show key metadata
+    if (result.data.metadata && Object.keys(result.data.metadata).length > 0) {
+      console.log('\n🏷️  Key Metadata:');
+      const keyFields = ['title', 'description', 'statusCode', 'contentType', 'creditsUsed'];
+      keyFields.forEach((field) => {
+        if (result.data!.metadata[field] !== undefined) {
+          console.log(`  - ${field}: ${result.data!.metadata[field]}`);
+        }
+      });
+
+      const totalKeys = Object.keys(result.data.metadata).length;
+      const shownKeys = keyFields.filter(
+        (field) => result.data!.metadata[field] !== undefined
+      ).length;
+      if (totalKeys > shownKeys) {
+        console.log(`  ... and ${totalKeys - shownKeys} more metadata fields`);
+      }
+    }
+  } catch (error) {
+    console.log(
+      `❌ Firecrawl scraping client error: ${error instanceof Error ? error.message : 'Unknown error'}`
+    );
+  }
+}
+
+// CLI usage
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const url = process.argv[2];
+  if (!url) {
+    console.log('Usage: node --import tsx tests/manual/firecrawl-scraping.manual.test.ts <url>');
+    console.log(
+      'Example: node --import tsx tests/manual/firecrawl-scraping.manual.test.ts https://espn.com'
+    );
+    console.log('\nRun from the pulse-fetch directory:');
+    console.log(
+      'cd productionized/pulse-fetch && node --import tsx tests/manual/firecrawl-scraping.manual.test.ts <url>'
+    );
+    process.exit(1);
+  }
+
+  testFirecrawlScrapingClient(url).catch(console.error);
+}
+
+export { testFirecrawlScrapingClient };

--- a/productionized/pulse-fetch/tests/manual/native-scraping.manual.test.ts
+++ b/productionized/pulse-fetch/tests/manual/native-scraping.manual.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Manual test for native scraping client
+ *
+ * One-liner command (run from pulse-fetch directory):
+ * node --import tsx tests/manual/native-scraping.manual.test.ts https://example.com
+ */
+
+import 'dotenv/config';
+import { NativeScrapingClient } from '../../shared/src/scraping-client/native-scrape-client.js';
+
+async function testNativeScrapingClient(url: string) {
+  console.log(`🔍 Testing Native Scraping Client for: ${url}`);
+  console.log('='.repeat(60));
+
+  const client = new NativeScrapingClient();
+
+  try {
+    const result = await client.scrape(url, {
+      timeout: 10000,
+    });
+
+    if (!result.success) {
+      console.log(`❌ Native scraping failed: ${result.error}`);
+      console.log(`📈 Status Code: ${result.statusCode || 'unknown'}`);
+      return;
+    }
+
+    console.log(`✅ Native scraping successful`);
+    console.log(`📈 Status Code: ${result.statusCode}`);
+    console.log(`📊 Content-Type: ${result.contentType || 'unknown'}`);
+    console.log(`📏 Content-Length: ${result.contentLength || 'unknown'}`);
+    console.log(`📝 Data length: ${result.data?.length || 0} characters`);
+
+    if (result.data) {
+      // Show first 500 characters
+      console.log('\n📖 Content preview:');
+      console.log('-'.repeat(40));
+      console.log(result.data.slice(0, 500) + (result.data.length > 500 ? '...' : ''));
+      console.log('-'.repeat(40));
+
+      // Basic content analysis
+      const hasTitle = /<title[^>]*>([^<]+)<\/title>/i.test(result.data);
+      const hasJavaScript = /<script[^>]*>/i.test(result.data);
+      const hasStructuredContent = /<(article|main|section|div)[^>]*>/i.test(result.data);
+
+      console.log('\n🔍 Content analysis:');
+      console.log(`  - Has title tag: ${hasTitle ? '✅' : '❌'}`);
+      console.log(`  - Has JavaScript: ${hasJavaScript ? '✅' : '❌'}`);
+      console.log(`  - Has structured content: ${hasStructuredContent ? '✅' : '❌'}`);
+    }
+
+    // Show response headers
+    if (result.headers && Object.keys(result.headers).length > 0) {
+      console.log('\n📋 Response headers:');
+      Object.entries(result.headers)
+        .slice(0, 5)
+        .forEach(([key, value]) => {
+          console.log(`  - ${key}: ${value}`);
+        });
+      if (Object.keys(result.headers).length > 5) {
+        console.log(`  ... and ${Object.keys(result.headers).length - 5} more headers`);
+      }
+    }
+  } catch (error) {
+    console.log(
+      `❌ Native scraping client error: ${error instanceof Error ? error.message : 'Unknown error'}`
+    );
+  }
+}
+
+// CLI usage
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const url = process.argv[2];
+  if (!url) {
+    console.log('Usage: node --import tsx tests/manual/native-scraping.manual.test.ts <url>');
+    console.log(
+      'Example: node --import tsx tests/manual/native-scraping.manual.test.ts https://pulsemcp.com'
+    );
+    console.log('\nRun from the pulse-fetch directory:');
+    console.log(
+      'cd productionized/pulse-fetch && node --import tsx tests/manual/native-scraping.manual.test.ts <url>'
+    );
+    process.exit(1);
+  }
+
+  testNativeScrapingClient(url).catch(console.error);
+}
+
+export { testNativeScrapingClient };

--- a/productionized/pulse-fetch/vitest.config.ts
+++ b/productionized/pulse-fetch/vitest.config.ts
@@ -5,7 +5,13 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'node',
-    exclude: ['**/node_modules/**', '**/dist/**', '**/build/**', '**/integration/**'],
+    exclude: [
+      '**/node_modules/**',
+      '**/dist/**',
+      '**/build/**',
+      '**/integration/**',
+      '**/manual/**',
+    ],
   },
   resolve: {
     alias: {


### PR DESCRIPTION
Publishing Pulse Fetch MCP server version 0.0.4

## Summary

This release adds a comprehensive manual test suite and refactors the scraping functionality to use proper client classes following MCP architecture patterns.

## Changes

### Added
- **Native scraping client class** following MCP client architecture patterns
- **Comprehensive manual test suite** with individual client tests for each scraping mode
- **Class-based scraping client architecture** (NativeScrapingClient, FirecrawlScrapingClient, BrightDataScrapingClient)
- **Enhanced manual testing** with one-liner commands for debugging different URLs
- **Detailed content analysis** and response statistics in manual tests
- **README documentation** for manual test usage and debugging

### Changed
- Refactored scraping clients from functions to class-based implementations
- Improved manual test output with better formatting and analysis
- Enhanced error detection and success/failure reporting in tests

### Fixed
- Fixed import paths and TypeScript compilation issues in manual tests
- Improved error handling in scraping client classes

## Manual Test Commands

```bash
# Run from productionized/pulse-fetch directory:
node --import tsx tests/manual/native-scraping.manual.test.ts <url>
node --import tsx tests/manual/firecrawl-scraping.manual.test.ts <url>
node --import tsx tests/manual/brightdata-scraping.manual.test.ts <url>
node --import tsx tests/manual/comprehensive-suite.manual.test.ts
```

## Architecture Improvements

- All scraping clients now follow consistent class-based patterns similar to twist-client
- Enhanced testability with proper client instantiation
- Better separation of concerns with TypeScript interfaces
- Comprehensive test coverage for debugging different scraping scenarios

## Checklist

- [x] Version bumped in package.json (0.0.3 → 0.0.4)
- [x] CHANGELOG.md updated with new version section
- [x] All tests passing (functional, integration, and manual)
- [x] Build succeeds
- [x] No sensitive information in code
- [x] Git tag created and pushed (@pulsemcp/pulse-fetch@0.0.4)
- [x] Main README.md updated (changed "Not Yet Published" to "0.0.4")
- [x] Linting passes with no warnings

🤖 Generated with [Claude Code](https://claude.ai/code)