### PR TITLE
fix: increase npm registry validation timeout and improve release creation

### DIFF
--- a/.github/workflows/publish-mcp-servers.yml
+++ b/.github/workflows/publish-mcp-servers.yml
@@ -5,6 +5,11 @@ on:
     branches:
       - main
 
+permissions:
+  contents: write # Required for creating releases
+  actions: read # Required for checking workflow status
+  checks: read # Required for checking CI status
+
 jobs:
   wait-for-ci:
     name: Wait for CI
@@ -157,6 +162,7 @@ jobs:
         if: steps.detect-changes.outputs.publish_needed == 'true'
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -e
 
@@ -198,10 +204,11 @@ jobs:
               
               # Wait for npm registry propagation and verify package metadata
               echo "Waiting for npm registry propagation..."
-              for i in {1..12}; do
+              # Increase timeout to 3 minutes (36 iterations × 5 seconds)
+              for i in {1..36}; do
                 PUBLISHED_VERSION=$(npm view "$PACKAGE_NAME@$PACKAGE_VERSION" version 2>/dev/null)
                 if [ "$PUBLISHED_VERSION" = "$PACKAGE_VERSION" ]; then
-                  echo "✅ Package $PACKAGE_NAME@$PACKAGE_VERSION available on npm registry"
+                  echo "✅ Package $PACKAGE_NAME@$PACKAGE_VERSION available on npm registry (after $((i * 5)) seconds)"
                   
                   # Additional validation: check package has required metadata
                   MAIN_FIELD=$(npm view "$PACKAGE_NAME@$PACKAGE_VERSION" main 2>/dev/null)
@@ -221,11 +228,13 @@ jobs:
                   
                   break
                 fi
-                if [ $i -eq 12 ]; then
-                  echo "❌ Package not available after 60 seconds - registry propagation failed"
+                if [ $i -eq 36 ]; then
+                  echo "❌ Package not available after 180 seconds - registry propagation failed"
+                  echo "However, npm publish reported success. This might be a temporary registry issue."
+                  echo "Please verify manually at: https://www.npmjs.com/package/$PACKAGE_NAME"
                   VALIDATION_FAILED=true
                 fi
-                echo "Waiting for registry propagation... ($i/12)"
+                echo "Waiting for registry propagation... ($i/36, $((i * 5)) seconds elapsed)"
                 sleep 5
               done
               
@@ -255,10 +264,32 @@ jobs:
                 
                 # Create release using GitHub CLI
                 if command -v gh &> /dev/null; then
-                  echo "$RELEASE_NOTES" | gh release create "$TAG_NAME" \
-                    --title "$PACKAGE_NAME v$PACKAGE_VERSION" \
-                    --notes-file - \
-                    || echo "Failed to create GitHub release (tag might not exist)"
+                  echo "GitHub CLI is available, attempting to create release for $TAG_NAME"
+                  
+                  # Check if tag exists
+                  if git rev-parse "$TAG_NAME" &> /dev/null; then
+                    echo "Git tag $TAG_NAME exists"
+                    
+                    # Check if release already exists
+                    if gh release view "$TAG_NAME" &> /dev/null; then
+                      echo "GitHub release already exists for $TAG_NAME, skipping creation"
+                    else
+                      # Create the release
+                      echo "Creating GitHub release for $TAG_NAME..."
+                      if echo "$RELEASE_NOTES" | gh release create "$TAG_NAME" \
+                        --title "$PACKAGE_NAME v$PACKAGE_VERSION" \
+                        --notes-file -; then
+                        echo "✅ Successfully created GitHub release for $TAG_NAME"
+                      else
+                        echo "WARNING: Failed to create GitHub release for $TAG_NAME (exit code: $?)"
+                        echo "This is non-fatal - the package was still published to npm successfully"
+                      fi
+                    fi
+                  else
+                    echo "WARNING: Git tag $TAG_NAME does not exist, skipping release creation"
+                  fi
+                else
+                  echo "GitHub CLI not available, skipping release creation"
                 fi
               fi
             else

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -242,3 +242,9 @@ Don't add: basic TypeScript fixes, standard npm troubleshooting, obvious file op
 - Branch naming follows `<github-username>/<feature-description>` pattern
 - Always ensure CI passes before considering a PR complete
 - Pre-commit hooks automatically run lint-staged, but manual linting should still be run before pushing to avoid CI failures
+
+### CI/CD Publication Workflow
+
+- The npm registry validation timeout can cause false failures - packages may be successfully published but take longer than expected to propagate
+- When debugging "exit code 1" failures in the publish workflow, check if FAILED_SERVERS was populated due to validation timeout
+- npm registry propagation can take 60+ seconds during high load times, so validation timeouts should be generous (3+ minutes)


### PR DESCRIPTION
## Summary

- Fixes CI failures when npm packages are successfully published but validation times out
- Increases npm registry validation timeout from 60s to 180s
- Improves GitHub release creation error handling

## Problem

The CI was failing even when packages were successfully published to npm. The issue was identified in the failed CI run for `@pulsemcp/pulse-fetch@0.1.0`:
- Package was successfully published to npm (verified at https://www.npmjs.com/package/@pulsemcp/pulse-fetch)
- CI reported failure with exit code 1
- Root cause: npm registry propagation took longer than the 60-second timeout

## Solution

1. **Increased validation timeout**: From 60 seconds to 180 seconds (3 minutes) to handle slower npm registry propagation
2. **Better progress tracking**: Shows elapsed time during validation wait
3. **Improved error messages**: Provides context when validation times out
4. **GitHub release improvements**:
   - Added proper workflow permissions (`contents: write`)
   - Added `GITHUB_TOKEN` to environment
   - Check if tag/release already exist before creating
   - Make release creation failures non-fatal

## Test Plan

- [x] Verified the workflow syntax is valid
- [x] Linting passes
- [ ] Next package publication will validate the fix

🤖 Generated with [Claude Code](https://claude.ai/code)