### PR TITLE
fix: prevent npm view errors from terminating publish validation

### DIFF
--- a/.github/workflows/publish-mcp-servers.yml
+++ b/.github/workflows/publish-mcp-servers.yml
@@ -200,13 +200,13 @@ jobs:
               echo "Waiting for npm registry propagation..."
               # Increase timeout to 3 minutes (36 iterations × 5 seconds)
               for i in {1..36}; do
-                PUBLISHED_VERSION=$(npm view "$PACKAGE_NAME@$PACKAGE_VERSION" version 2>/dev/null)
+                PUBLISHED_VERSION=$(npm view "$PACKAGE_NAME@$PACKAGE_VERSION" version 2>/dev/null || true)
                 if [ "$PUBLISHED_VERSION" = "$PACKAGE_VERSION" ]; then
                   echo "✅ Package $PACKAGE_NAME@$PACKAGE_VERSION available on npm registry"
                   
                   # Additional validation: check package has required metadata
-                  MAIN_FIELD=$(npm view "$PACKAGE_NAME@$PACKAGE_VERSION" main 2>/dev/null)
-                  FILES_FIELD=$(npm view "$PACKAGE_NAME@$PACKAGE_VERSION" files 2>/dev/null)
+                  MAIN_FIELD=$(npm view "$PACKAGE_NAME@$PACKAGE_VERSION" main 2>/dev/null || true)
+                  FILES_FIELD=$(npm view "$PACKAGE_NAME@$PACKAGE_VERSION" files 2>/dev/null || true)
                   
                   if [ -z "$MAIN_FIELD" ]; then
                     echo "⚠️  Warning: Package missing 'main' field in package.json"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -261,3 +261,4 @@ Don't add: basic TypeScript fixes, standard npm troubleshooting, obvious file op
 - The version bump commit should include all modified files: local/package.json, local/package-lock.json, parent package-lock.json, CHANGELOG.md, and main README.md
 - When simplifying tool parameters, consider the MCP best practices guide in mcp-server-template/shared/src/tools/TOOL_DESCRIPTIONS_GUIDE.md for writing clear descriptions
 - Breaking changes in tool parameters should be clearly marked in CHANGELOG.md with **BREAKING** prefix to alert users
+- When using `set -e` in shell scripts with npm commands, be aware that `npm view` returns exit code 1 when a package doesn't exist yet - use `|| true` to prevent premature script termination during npm registry propagation checks


### PR DESCRIPTION
## Summary
- Fixed CI failure where npm validation was terminating prematurely after successful publish
- Added `|| true` to npm view commands to prevent non-zero exit codes from terminating the validation loop

## Problem
The publish workflow was failing during npm registry validation because:
1. The script has `set -e` enabled (exit on any error)
2. `npm view` returns exit code 1 when a package hasn't propagated to npm yet
3. This caused the script to exit immediately, before the package had time to propagate

## Solution
Added `|| true` to all `npm view` commands in the validation loop to prevent them from causing script termination while still capturing their output.

## Test plan
- [x] Verified the fix addresses the exact error seen in the failed CI run
- [x] The next publish to main should validate correctly without premature termination
- [ ] Monitor the next automated publish to ensure validation waits the full timeout if needed

🤖 Generated with [Claude Code](https://claude.ai/code)