### PR TITLE
chore: bump @pulsemcp/pulse-fetch to 0.2.4

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -355,3 +355,4 @@ Don't add: basic TypeScript fixes, standard npm troubleshooting, obvious file op
 - **SDK Updates**: When updating @modelcontextprotocol/sdk, update it in both shared/package.json and local/package.json, never in the root
 - **Common Mistake**: Running `npm install <package> --save` from the server root directory adds dependencies to the wrong package.json - always cd into shared/ or local/ first
 - **CI Installation**: All MCP servers now have a `ci:install` script that ensures dependencies are installed in all subdirectories - this prevents `ERR_MODULE_NOT_FOUND` errors in published packages that occur when CI only runs `npm install` at the root level
+- **Published Package Dependencies**: When adding new dependencies to shared/, they MUST also be added to local/package.json to ensure they're included in the published npm package - the prepare-publish.js script only copies built JS files, not node_modules

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ These are PulseMCP-branded servers that we intend to maintain indefinitely as ou
 
 | Name                                         | Description                          | Local Status | Remote Status | Target Audience                                                                                        | Notes                                                                                                  |
 | -------------------------------------------- | ------------------------------------ | ------------ | ------------- | ------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------ |
-| [pulse-fetch](./productionized/pulse-fetch/) | Pull internet resources into context | 0.2.3        | Not Started   | Agent-building frameworks (e.g. fast-agent, Mastra, PydanticAI) and MCP clients without built-in fetch | Supports Firecrawl and BrightData integrations; HTML noise stripping; Resource caching; LLM extraction |
+| [pulse-fetch](./productionized/pulse-fetch/) | Pull internet resources into context | 0.2.4        | Not Started   | Agent-building frameworks (e.g. fast-agent, Mastra, PydanticAI) and MCP clients without built-in fetch | Supports Firecrawl and BrightData integrations; HTML noise stripping; Resource caching; LLM extraction |
 
 ### Experimental Servers
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ These are PulseMCP-branded servers that we intend to maintain indefinitely as ou
 
 | Name                                         | Description                          | Local Status | Remote Status | Target Audience                                                                                        | Notes                                                                                                  |
 | -------------------------------------------- | ------------------------------------ | ------------ | ------------- | ------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------ |
-| [pulse-fetch](./productionized/pulse-fetch/) | Pull internet resources into context | 0.2.2        | Not Started   | Agent-building frameworks (e.g. fast-agent, Mastra, PydanticAI) and MCP clients without built-in fetch | Supports Firecrawl and BrightData integrations; HTML noise stripping; Resource caching; LLM extraction |
+| [pulse-fetch](./productionized/pulse-fetch/) | Pull internet resources into context | 0.2.3        | Not Started   | Agent-building frameworks (e.g. fast-agent, Mastra, PydanticAI) and MCP clients without built-in fetch | Supports Firecrawl and BrightData integrations; HTML noise stripping; Resource caching; LLM extraction |
 
 ### Experimental Servers
 

--- a/productionized/pulse-fetch/CHANGELOG.md
+++ b/productionized/pulse-fetch/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.4] - 2025-07-01
+
+### Changed
+
+- Updated documentation to clarify dependency management in workspace packages
+
 ## [0.2.3] - 2025-07-01
 
 ### Fixed

--- a/productionized/pulse-fetch/CHANGELOG.md
+++ b/productionized/pulse-fetch/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.3] - 2025-07-01
+
+### Fixed
+
+- Fixed missing dependencies in published package
+  - Added `@anthropic-ai/sdk` and `openai` to local package.json
+  - These dependencies were only in shared/package.json causing ERR_MODULE_NOT_FOUND in published package
+
 ## [0.2.2] - 2025-07-01
 
 ### Fixed

--- a/productionized/pulse-fetch/local/package.json
+++ b/productionized/pulse-fetch/local/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/pulse-fetch",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Local implementation of pulse-fetch MCP server",
   "main": "build/index.js",
   "type": "module",
@@ -29,7 +29,9 @@
     "stage-publish": "npm version"
   },
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.36.3",
     "@modelcontextprotocol/sdk": "^1.13.2",
+    "openai": "^4.104.0",
     "zod": "^3.24.1"
   },
   "devDependencies": {

--- a/productionized/pulse-fetch/local/package.json
+++ b/productionized/pulse-fetch/local/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulsemcp/pulse-fetch",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Local implementation of pulse-fetch MCP server",
   "main": "build/index.js",
   "type": "module",

--- a/productionized/pulse-fetch/package-lock.json
+++ b/productionized/pulse-fetch/package-lock.json
@@ -31,7 +31,7 @@
     },
     "local": {
       "name": "@pulsemcp/pulse-fetch",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.36.3",

--- a/productionized/pulse-fetch/package-lock.json
+++ b/productionized/pulse-fetch/package-lock.json
@@ -31,10 +31,12 @@
     },
     "local": {
       "name": "@pulsemcp/pulse-fetch",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "MIT",
       "dependencies": {
+        "@anthropic-ai/sdk": "^0.36.3",
         "@modelcontextprotocol/sdk": "^1.13.2",
+        "openai": "^4.104.0",
         "zod": "^3.24.1"
       },
       "bin": {
@@ -48,7 +50,8 @@
     },
     "node_modules/@anthropic-ai/sdk": {
       "version": "0.36.3",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.36.3.tgz",
+      "integrity": "sha512-+c0mMLxL/17yFZ4P5+U6bTWiCSFZUKJddrv01ud2aFBWnTPLdRncYV76D3q1tqfnL7aCnhRtykFnoCFzvr4U3Q==",
       "dependencies": {
         "@types/node": "^18.11.18",
         "@types/node-fetch": "^2.6.4",
@@ -1269,7 +1272,8 @@
     },
     "node_modules/openai": {
       "version": "4.104.0",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-4.104.0.tgz",
+      "integrity": "sha512-p99EFNsA/yX6UhVO93f5kJsDRLAg+CTA2RBqdHK4RtK8u5IJw32Hyb2dTGKbnnFmnuoBv5r7Z2CURI9sGZpSuA==",
       "dependencies": {
         "@types/node": "^18.11.18",
         "@types/node-fetch": "^2.6.4",


### PR DESCRIPTION
## Summary

Minor version bump with documentation updates about dependency management in workspace packages.

## Changes

- Bumped @pulsemcp/pulse-fetch to 0.2.4
- Added learning to CLAUDE.md about ensuring dependencies are in both shared/ and local/ package.json files

## Context

This follows the fix in 0.2.3 where we resolved the missing dependencies issue. This version includes documentation updates to prevent similar issues in the future.

## Test Plan

- [x] Local npm publish tested successfully with 0.2.3
- [x] Verified npx command works with published package
- [ ] CI checks pass

## 📦 Version Status

Version 0.2.4 has been staged for publishing. CI will automatically publish to npm when this PR is merged.

🤖 Generated with [Claude Code](https://claude.ai/code)