### PR TITLE
fix: enable GitHub release creation in CI/CD workflow

### DIFF
--- a/.github/workflows/publish-mcp-servers.yml
+++ b/.github/workflows/publish-mcp-servers.yml
@@ -69,6 +69,9 @@ jobs:
   detect-and-publish:
     needs: wait-for-ci
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
 
     steps:
       - name: Checkout code
@@ -157,6 +160,7 @@ jobs:
         if: steps.detect-changes.outputs.publish_needed == 'true'
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -e
 
@@ -260,11 +264,21 @@ jobs:
                 fi
                 
                 # Create release using GitHub CLI
-                if command -v gh &> /dev/null; then
-                  echo "$RELEASE_NOTES" | gh release create "$TAG_NAME" \
-                    --title "$PACKAGE_NAME v$PACKAGE_VERSION" \
-                    --notes-file - \
-                    || echo "Failed to create GitHub release (tag might not exist)"
+                echo "Creating GitHub release for $TAG_NAME..."
+                if echo "$RELEASE_NOTES" | gh release create "$TAG_NAME" \
+                  --title "$PACKAGE_NAME v$PACKAGE_VERSION" \
+                  --notes-file - \
+                  --target main; then
+                  echo "✅ GitHub release created successfully"
+                else
+                  echo "❌ Failed to create GitHub release"
+                  echo "Attempting to check if tag exists..."
+                  if ! git rev-parse "$TAG_NAME" >/dev/null 2>&1; then
+                    echo "Tag $TAG_NAME does not exist. The tag should have been created during 'npm version' command."
+                    echo "Check if the version bump process created the tag correctly."
+                  else
+                    echo "Tag exists but release creation failed. Check GitHub permissions."
+                  fi
                 fi
               fi
             else

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -335,7 +335,6 @@ Don't add: basic TypeScript fixes, standard npm troubleshooting, obvious file op
 - Branch naming follows `<github-username>/<feature-description>` pattern
 - Always ensure CI passes before considering a PR complete
 - Pre-commit hooks automatically run lint-staged, but manual linting should still be run before pushing to avoid CI failures
-- **GitHub Release Creation**: The CI/CD workflow creates GitHub releases when publishing npm packages, but requires: 1) `contents: write` permission in the workflow job, 2) `GITHUB_TOKEN` environment variable for `gh` CLI authentication, and 3) the git tag to exist (created by `npm version`). Without these, release creation fails silently
 
 ### Publishing Process
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -335,6 +335,7 @@ Don't add: basic TypeScript fixes, standard npm troubleshooting, obvious file op
 - Branch naming follows `<github-username>/<feature-description>` pattern
 - Always ensure CI passes before considering a PR complete
 - Pre-commit hooks automatically run lint-staged, but manual linting should still be run before pushing to avoid CI failures
+- **GitHub Release Creation**: The CI/CD workflow creates GitHub releases when publishing npm packages, but requires: 1) `contents: write` permission in the workflow job, 2) `GITHUB_TOKEN` environment variable for `gh` CLI authentication, and 3) the git tag to exist (created by `npm version`). Without these, release creation fails silently
 
 ### Publishing Process
 


### PR DESCRIPTION
## Summary
- Fixed GitHub release creation that was silently failing in the CI/CD workflow
- Added proper permissions and authentication for the GitHub CLI
- Improved error handling to diagnose release creation failures

## Changes
1. **Added workflow permissions**: Added `contents: write` and `packages: write` permissions to the `detect-and-publish` job
2. **Added GITHUB_TOKEN**: Set up proper authentication for the `gh` CLI by adding `GITHUB_TOKEN` environment variable
3. **Enhanced error handling**: Added detailed diagnostics when release creation fails, including checks for missing git tags
4. **Added target branch**: Specified `--target main` to ensure releases target the correct branch

## Why These Changes Are Needed
The workflow was attempting to create GitHub releases but failing silently due to:
- Missing permissions to write to the repository (create releases)
- No authentication token for the GitHub CLI
- Silent error handling that masked the failures

## Testing
These changes will be tested when the next server version is published. The workflow will now:
- Successfully create GitHub releases for each published server version
- Show clear error messages if something goes wrong
- Help diagnose issues with missing git tags

## Impact
Once merged, all future npm package releases will automatically create corresponding GitHub releases with:
- Proper version tags (e.g., `@pulsemcp/pulse-fetch@0.2.5`)
- Changelog entries from the server's CHANGELOG.md
- Links to the npm package