### PR TITLE
fix: improve GitHub release creation in CI workflow

### DIFF
--- a/.github/workflows/publish-mcp-servers.yml
+++ b/.github/workflows/publish-mcp-servers.yml
@@ -256,9 +256,15 @@ jobs:
                 CHANGELOG_FILE="$SERVER_DIR/CHANGELOG.md"
                 if [ -f "$CHANGELOG_FILE" ]; then
                   # Extract the changelog section for this version
-                  CHANGELOG_ENTRY=$(awk "/## \[$PACKAGE_VERSION\]/{flag=1; next} /## \[/{flag=0} flag" "$CHANGELOG_FILE")
+                  # Look for version with or without 'v' prefix and handle both formats
+                  CHANGELOG_ENTRY=$(awk "/## \[v?$PACKAGE_VERSION\]/{flag=1; next} /## \[/{flag=0} flag" "$CHANGELOG_FILE" | sed '/^$/d')
                   
-                  RELEASE_NOTES="# $PACKAGE_NAME v$PACKAGE_VERSION"$'\n\n'"$CHANGELOG_ENTRY"$'\n\n'"---"$'\n'"Published to npm: https://www.npmjs.com/package/$PACKAGE_NAME"
+                  if [ -z "$CHANGELOG_ENTRY" ]; then
+                    echo "Warning: No changelog entry found for version $PACKAGE_VERSION"
+                    RELEASE_NOTES="# $PACKAGE_NAME v$PACKAGE_VERSION"$'\n\n'"Published to npm: https://www.npmjs.com/package/$PACKAGE_NAME"
+                  else
+                    RELEASE_NOTES="# $PACKAGE_NAME v$PACKAGE_VERSION"$'\n\n'"$CHANGELOG_ENTRY"$'\n\n'"---"$'\n'"Published to npm: https://www.npmjs.com/package/$PACKAGE_NAME"
+                  fi
                 else
                   RELEASE_NOTES="# $PACKAGE_NAME v$PACKAGE_VERSION"$'\n\n'"Published to npm: https://www.npmjs.com/package/$PACKAGE_NAME"
                 fi
@@ -268,7 +274,8 @@ jobs:
                 if echo "$RELEASE_NOTES" | gh release create "$TAG_NAME" \
                   --title "$PACKAGE_NAME v$PACKAGE_VERSION" \
                   --notes-file - \
-                  --target main; then
+                  --target main \
+                  --latest=false; then
                   echo "✅ GitHub release created successfully"
                 else
                   echo "❌ Failed to create GitHub release"


### PR DESCRIPTION
## Summary

- Fixed GitHub releases to include changelog content from CHANGELOG.md files
- Removed the "Latest" tag from all releases in the monorepo setup
- Improved changelog extraction to handle versions with or without 'v' prefix

## Changes

1. **Enhanced changelog extraction in CI**:
   - Modified the awk pattern to support both `[0.2.6]` and `[v0.2.6]` formats
   - Added empty line removal for cleaner release notes
   - Added warning when no changelog entry is found for a version

2. **Fixed monorepo release tagging**:
   - Added `--latest=false` flag to `gh release create` command
   - This prevents the "only one latest" issue in monorepos where multiple packages are released

## Test plan

- [x] Verified the awk pattern correctly extracts changelog entries
- [x] Confirmed the `--latest=false` flag is supported by GitHub CLI
- [ ] The next release cycle will show improved release notes with full changelog content
- [ ] No releases will be marked as "Latest" going forward

🤖 Generated with [Claude Code](https://claude.ai/code)