### PR TITLE
fix(pulse-fetch): detect correct MIME type for scraped resources

### DIFF
--- a/productionized/pulse-fetch/CHANGELOG.md
+++ b/productionized/pulse-fetch/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed incorrect MIME type detection for scraped resources
+  - Resources now properly detect content type based on actual content (text/html, application/json, application/xml, text/plain)
+  - Previously all resources were incorrectly marked as text/plain regardless of content
+  - Added comprehensive functional tests for MIME type detection
+
 ## [0.2.7] - 2025-07-03
 
 ### Fixed

--- a/productionized/pulse-fetch/package-lock.json
+++ b/productionized/pulse-fetch/package-lock.json
@@ -56,7 +56,6 @@
       "version": "0.36.3",
       "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.36.3.tgz",
       "integrity": "sha512-+c0mMLxL/17yFZ4P5+U6bTWiCSFZUKJddrv01ud2aFBWnTPLdRncYV76D3q1tqfnL7aCnhRtykFnoCFzvr4U3Q==",
-      "license": "MIT",
       "dependencies": {
         "@types/node": "^18.11.18",
         "@types/node-fetch": "^2.6.4",
@@ -2076,7 +2075,6 @@
       "version": "26.1.0",
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
       "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
-      "license": "MIT",
       "dependencies": {
         "cssstyle": "^4.2.1",
         "data-urls": "^5.0.0",
@@ -2346,7 +2344,6 @@
       "version": "4.104.0",
       "resolved": "https://registry.npmjs.org/openai/-/openai-4.104.0.tgz",
       "integrity": "sha512-p99EFNsA/yX6UhVO93f5kJsDRLAg+CTA2RBqdHK4RtK8u5IJw32Hyb2dTGKbnnFmnuoBv5r7Z2CURI9sGZpSuA==",
-      "license": "Apache-2.0",
       "dependencies": {
         "@types/node": "^18.11.18",
         "@types/node-fetch": "^2.6.4",


### PR DESCRIPTION
## Summary
- Fixed incorrect MIME type detection for scraped resources
- Resources now properly detect content type based on actual content (text/html, application/json, application/xml, text/plain)
- Previously all resources were incorrectly marked as text/plain regardless of content

## Changes
- Added `detectContentType` function to analyze content and determine appropriate MIME type
- Updated resource storage to include detected content type in metadata
- Fixed resource link MIME type to use detected content type instead of hardcoded values
- Added comprehensive functional tests for MIME type detection

## Test plan
- [x] Added comprehensive functional tests covering HTML, JSON, XML, and plain text detection
- [x] All existing tests pass
- [x] Manually verified HTML content is now correctly identified as text/html

Fixes issue where HTML content was incorrectly marked as text/plain in MCP resources.

🤖 Generated with [Claude Code](https://claude.ai/code)