### PR TITLE
refactor: standardize build output directory from 'dist' to 'build' across monorepo

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -17,5 +17,5 @@
     "@typescript-eslint/no-unused-vars": ["error", { "argsIgnorePattern": "^_" }],
     "@typescript-eslint/no-explicit-any": "error"
   },
-  "ignorePatterns": ["node_modules", "dist", "build", "*.js", "*.mjs", "*.cjs", "**/local/shared"]
+  "ignorePatterns": ["node_modules", "build", "*.js", "*.mjs", "*.cjs", "**/local/shared"]
 }

--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@ node_modules
 .pnp/
 
 # Build outputs
-dist/
 build/
 *.tsbuildinfo
 
@@ -15,7 +14,6 @@ build/
 **/*.d.ts
 **/*.d.ts.map
 # Exclude build directories from the above patterns
-!**/dist/**
 !**/build/**
 !**/node_modules/**
 # Keep helper scripts

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -359,9 +359,3 @@ Don't add: basic TypeScript fixes, standard npm troubleshooting, obvious file op
 ### Changelog management
 
 Whenever you make any sort of code change to an MCP server, make sure to update the unreleased section of its corresponding `CHANGELOG.md`.
-
-### Build Directory Management
-
-- **Standardized Build Output**: All MCP servers use `build` as the output directory (not `dist`) for consistency across the monorepo
-- **Clean Script Pattern**: Use glob patterns in the root clean script (e.g., `experimental/**/build`) instead of enumerating every single directory - this is more maintainable and handles nested structures automatically
-- **Gitignore Cleanup**: When standardizing build directories, remove redundant entries from .gitignore files - having both `dist/` and `build/` is unnecessary when only using `build/`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -359,3 +359,9 @@ Don't add: basic TypeScript fixes, standard npm troubleshooting, obvious file op
 ### Changelog management
 
 Whenever you make any sort of code change to an MCP server, make sure to update the unreleased section of its corresponding `CHANGELOG.md`.
+
+### Build Directory Management
+
+- **Standardized Build Output**: All MCP servers use `build` as the output directory (not `dist`) for consistency across the monorepo
+- **Clean Script Pattern**: Use glob patterns in the root clean script (e.g., `experimental/**/build`) instead of enumerating every single directory - this is more maintainable and handles nested structures automatically
+- **Gitignore Cleanup**: When standardizing build directories, remove redundant entries from .gitignore files - having both `dist/` and `build/` is unnecessary when only using `build/`

--- a/experimental/appsignal/.gitignore
+++ b/experimental/appsignal/.gitignore
@@ -2,14 +2,12 @@
 node_modules/
 
 # Build output
-dist/
 build/
 
 # TypeScript compiled files in source directories
 **/*.js
 **/*.js.map
 **/*.d.ts
-!**/dist/**
 !**/build/**
 !scripts/**/*.js
 !local/prepare-publish.js

--- a/experimental/appsignal/local/prepare-publish.js
+++ b/experimental/appsignal/local/prepare-publish.js
@@ -56,7 +56,7 @@ async function prepare() {
   }
 
   // Copy the built shared files
-  await cp(join(__dirname, '../shared/dist'), join(__dirname, 'shared'), { recursive: true });
+  await cp(join(__dirname, '../shared/build'), join(__dirname, 'shared'), { recursive: true });
 
   console.log('Copied shared files to local package');
 }

--- a/experimental/appsignal/local/setup-dev.js
+++ b/experimental/appsignal/local/setup-dev.js
@@ -7,7 +7,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 
 async function setupDev() {
   const linkPath = join(__dirname, 'shared');
-  const targetPath = join(__dirname, '../shared/dist');
+  const targetPath = join(__dirname, '../shared/build');
 
   try {
     await unlink(linkPath);

--- a/experimental/appsignal/local/src/index.integration-with-mock.ts
+++ b/experimental/appsignal/local/src/index.integration-with-mock.ts
@@ -9,7 +9,7 @@
  */
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { createMCPServer } from 'appsignal-mcp-server-shared';
-import { createIntegrationMockAppsignalClient } from 'appsignal-mcp-server-shared/dist/appsignal-client/appsignal-client.integration-mock.js';
+import { createIntegrationMockAppsignalClient } from 'appsignal-mcp-server-shared/build/appsignal-client/appsignal-client.integration-mock.js';
 
 async function main() {
   const transport = new StdioServerTransport();

--- a/experimental/appsignal/package.json
+++ b/experimental/appsignal/package.json
@@ -14,7 +14,7 @@
     "ci:install": "npm ci && cd shared && npm ci && cd ../local && npm ci",
     "build": "cd shared && npm run build && cd ../local && npm run build",
     "build:test": "cd shared && npm run build && cd ../local && npm run build && cd ../../../test-mcp-client && npm run build",
-    "clean": "find . -name '*.js' -not -path './node_modules/*' -not -path './*/node_modules/*' -not -path './local/build/*' -not -path './shared/dist/*' -not -path './*/dist/*' -not -path './*/build/*' -delete && find . -name '*.js.map' -not -path './node_modules/*' -not -path './*/node_modules/*' -not -path './local/build/*' -not -path './shared/dist/*' -not -path './*/dist/*' -not -path './*/build/*' -delete",
+    "clean": "find . -name '*.js' -not -path './node_modules/*' -not -path './*/node_modules/*' -not -path './local/build/*' -not -path './shared/build/*' -not -path './*/build/*' -delete && find . -name '*.js.map' -not -path './node_modules/*' -not -path './*/node_modules/*' -not -path './local/build/*' -not -path './shared/build/*' -not -path './*/build/*' -delete",
     "dev": "cd local && npm run dev",
     "test": "npm run build:test && vitest run",
     "test:ui": "vitest --ui",

--- a/experimental/appsignal/shared/package.json
+++ b/experimental/appsignal/shared/package.json
@@ -2,7 +2,7 @@
   "name": "appsignal-mcp-server-shared",
   "version": "0.1.0",
   "description": "Shared code for AppSignal MCP server implementations",
-  "main": "dist/index.js",
+  "main": "build/index.js",
   "type": "module",
   "scripts": {
     "build": "tsc"

--- a/experimental/appsignal/shared/tsconfig.json
+++ b/experimental/appsignal/shared/tsconfig.json
@@ -8,11 +8,11 @@
     "skipLibCheck": true,
     "declaration": true,
     "declarationMap": true,
-    "outDir": "./dist",
+    "outDir": "./build",
     "rootDir": "./src",
     "lib": ["ES2022"],
     "types": ["node"]
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "build"]
 }

--- a/experimental/appsignal/tests/integration/appsignal-new-tools.integration.test.ts
+++ b/experimental/appsignal/tests/integration/appsignal-new-tools.integration.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, afterEach } from 'vitest';
-import { TestMCPClient } from '../../../../test-mcp-client/dist/index.js';
+import { TestMCPClient } from '../../../../test-mcp-client/build/index.js';
 import { createIntegrationMockAppsignalClient } from '../../shared/src/appsignal-client/appsignal-client.integration-mock.js';
 import type { IAppsignalClient } from '../../shared/src/appsignal-client/appsignal-client.js';
 import type { MockData } from '../../shared/src/appsignal-client/appsignal-client.integration-mock.js';

--- a/experimental/appsignal/tests/integration/appsignal.integration.test.ts
+++ b/experimental/appsignal/tests/integration/appsignal.integration.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, afterEach } from 'vitest';
-import { TestMCPClient } from '../../../../test-mcp-client/dist/index.js';
+import { TestMCPClient } from '../../../../test-mcp-client/build/index.js';
 import { createIntegrationMockAppsignalClient } from '../../shared/src/appsignal-client/appsignal-client.integration-mock.js';
 import type { IAppsignalClient } from '../../shared/src/appsignal-client/appsignal-client.js';
 import path from 'path';

--- a/experimental/appsignal/tests/integration/dynamic-tool-naming.integration.test.ts
+++ b/experimental/appsignal/tests/integration/dynamic-tool-naming.integration.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, afterEach } from 'vitest';
-import { TestMCPClient } from '../../../../test-mcp-client/dist/index.js';
+import { TestMCPClient } from '../../../../test-mcp-client/build/index.js';
 import { createIntegrationMockAppsignalClient } from '../../shared/src/appsignal-client/appsignal-client.integration-mock.js';
 import type { IAppsignalClient } from '../../shared/src/appsignal-client/appsignal-client.js';
 import path from 'path';

--- a/experimental/appsignal/tests/integration/performance-tools.integration.test.ts
+++ b/experimental/appsignal/tests/integration/performance-tools.integration.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, afterEach } from 'vitest';
-import { TestMCPClient } from '../../../../test-mcp-client/dist/index.js';
+import { TestMCPClient } from '../../../../test-mcp-client/build/index.js';
 import { createIntegrationMockAppsignalClient } from '../../shared/src/appsignal-client/appsignal-client.integration-mock.js';
 import type { IAppsignalClient } from '../../shared/src/appsignal-client/appsignal-client.js';
 import type { MockData } from '../../shared/src/appsignal-client/appsignal-client.integration-mock.js';

--- a/experimental/appsignal/tests/manual/appsignal-new-tools.manual.test.ts
+++ b/experimental/appsignal/tests/manual/appsignal-new-tools.manual.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
-import { TestMCPClient } from '../../../../test-mcp-client/dist/index.js';
+import { TestMCPClient } from '../../../../test-mcp-client/build/index.js';
 import path from 'path';
 import { fileURLToPath } from 'url';
 

--- a/experimental/appsignal/tests/manual/appsignal.manual.test.ts
+++ b/experimental/appsignal/tests/manual/appsignal.manual.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
-import { TestMCPClient } from '../../../../test-mcp-client/dist/index.js';
+import { TestMCPClient } from '../../../../test-mcp-client/build/index.js';
 import path from 'path';
 import { fileURLToPath } from 'url';
 

--- a/experimental/appsignal/tests/manual/performance-tools.manual.test.ts
+++ b/experimental/appsignal/tests/manual/performance-tools.manual.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
-import { TestMCPClient } from '../../../../test-mcp-client/dist/index.js';
+import { TestMCPClient } from '../../../../test-mcp-client/build/index.js';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import type { TimelineEvent } from '../../shared/src/appsignal-client/lib/performance-incident-sample-timeline.js';

--- a/experimental/appsignal/tests/manual/production-app.manual.test.ts
+++ b/experimental/appsignal/tests/manual/production-app.manual.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
-import { TestMCPClient } from '../../../../test-mcp-client/dist/index.js';
+import { TestMCPClient } from '../../../../test-mcp-client/build/index.js';
 import path from 'path';
 import { fileURLToPath } from 'url';
 

--- a/experimental/appsignal/tsconfig.json
+++ b/experimental/appsignal/tsconfig.json
@@ -10,5 +10,5 @@
     "noEmit": true
   },
   "include": ["tests/**/*.ts"],
-  "exclude": ["node_modules", "**/dist", "**/build"]
+  "exclude": ["node_modules", "**/build"]
 }

--- a/experimental/appsignal/vitest.config.ts
+++ b/experimental/appsignal/vitest.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'node',
-    exclude: ['**/node_modules/**', '**/dist/**', '**/build/**', '**/manual/**'],
+    exclude: ['**/node_modules/**', '**/build/**', '**/manual/**'],
   },
   resolve: {
     alias: {

--- a/experimental/twist/.gitignore
+++ b/experimental/twist/.gitignore
@@ -3,7 +3,6 @@ node_modules/
 
 # Build output
 build/
-dist/
 *.tsbuildinfo
 
 # Environment files

--- a/experimental/twist/local/prepare-publish.js
+++ b/experimental/twist/local/prepare-publish.js
@@ -56,7 +56,7 @@ async function prepare() {
   }
 
   // Copy the built shared files
-  await cp(join(__dirname, '../shared/dist'), join(__dirname, 'shared'), { recursive: true });
+  await cp(join(__dirname, '../shared/build'), join(__dirname, 'shared'), { recursive: true });
 
   console.log('Copied shared files to local package');
 }

--- a/experimental/twist/local/setup-dev.js
+++ b/experimental/twist/local/setup-dev.js
@@ -7,7 +7,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 
 async function setupDev() {
   const linkPath = join(__dirname, 'shared');
-  const targetPath = join(__dirname, '../shared/dist');
+  const targetPath = join(__dirname, '../shared/build');
 
   try {
     await unlink(linkPath);

--- a/experimental/twist/local/src/index.integration-with-mock.ts
+++ b/experimental/twist/local/src/index.integration-with-mock.ts
@@ -11,7 +11,7 @@ import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import { createMCPServer } from 'twist-mcp-server-shared';
 // Import the mock client factory from the shared module
 // Note: This import path assumes the shared module is built and the integration mock is exported
-import { createIntegrationMockTwistClient } from 'twist-mcp-server-shared/dist/twist-client/twist-client.integration-mock.js';
+import { createIntegrationMockTwistClient } from 'twist-mcp-server-shared/build/twist-client/twist-client.integration-mock.js';
 
 async function main() {
   const transport = new StdioServerTransport();

--- a/experimental/twist/package.json
+++ b/experimental/twist/package.json
@@ -14,7 +14,7 @@
     "ci:install": "npm ci && cd shared && npm ci && cd ../local && npm ci",
     "build": "cd shared && npm run build && cd ../local && npm run build",
     "build:test": "cd shared && npm run build && cd ../local && npm run build && cd ../../../test-mcp-client && npm run build",
-    "clean": "find . -name '*.js' -not -path './node_modules/*' -not -path './*/node_modules/*' -not -path './local/build/*' -not -path './shared/dist/*' -not -path './*/dist/*' -not -path './*/build/*' -delete && find . -name '*.js.map' -not -path './node_modules/*' -not -path './*/node_modules/*' -not -path './local/build/*' -not -path './shared/dist/*' -not -path './*/dist/*' -not -path './*/build/*' -delete",
+    "clean": "find . -name '*.js' -not -path './node_modules/*' -not -path './*/node_modules/*' -not -path './local/build/*' -not -path './shared/build/*' -not -path './*/build/*' -delete && find . -name '*.js.map' -not -path './node_modules/*' -not -path './*/node_modules/*' -not -path './local/build/*' -not -path './shared/build/*' -not -path './*/build/*' -delete",
     "dev": "cd local && npm run dev",
     "test": "vitest",
     "test:run": "vitest run",

--- a/experimental/twist/shared/package.json
+++ b/experimental/twist/shared/package.json
@@ -2,7 +2,7 @@
   "name": "twist-mcp-server-shared",
   "version": "0.1.1",
   "description": "Shared code for Twist MCP Server implementations",
-  "main": "dist/index.js",
+  "main": "build/index.js",
   "type": "module",
   "scripts": {
     "build": "tsc",

--- a/experimental/twist/shared/tsconfig.json
+++ b/experimental/twist/shared/tsconfig.json
@@ -8,11 +8,11 @@
     "skipLibCheck": true,
     "declaration": true,
     "declarationMap": true,
-    "outDir": "./dist",
+    "outDir": "./build",
     "rootDir": "./src",
     "lib": ["es2022"],
     "types": ["node"]
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "build"]
 }

--- a/experimental/twist/tests/integration/twist.integration.test.ts
+++ b/experimental/twist/tests/integration/twist.integration.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { TestMCPClient } from '../../../../test-mcp-client/dist/index.js';
+import { TestMCPClient } from '../../../../test-mcp-client/build/index.js';
 // import { createIntegrationMockTwistClient } from '../../shared/src/twist-client/twist-client.integration-mock.js';
 import path from 'path';
 import { fileURLToPath } from 'url';

--- a/experimental/twist/tests/manual/explore-closed-thread.ts
+++ b/experimental/twist/tests/manual/explore-closed-thread.ts
@@ -1,5 +1,5 @@
 import { config } from 'dotenv';
-import { TestMCPClient } from '../../../../test-mcp-client/dist/index.js';
+import { TestMCPClient } from '../../../../test-mcp-client/build/index.js';
 import path from 'path';
 import { fileURLToPath } from 'url';
 

--- a/experimental/twist/tests/manual/test-pagination-filters.ts
+++ b/experimental/twist/tests/manual/test-pagination-filters.ts
@@ -1,5 +1,5 @@
 import { config } from 'dotenv';
-import { TestMCPClient } from '../../../../test-mcp-client/dist/index.js';
+import { TestMCPClient } from '../../../../test-mcp-client/build/index.js';
 import path from 'path';
 import { fileURLToPath } from 'url';
 

--- a/experimental/twist/tests/manual/test-pagination-offset-bug.ts
+++ b/experimental/twist/tests/manual/test-pagination-offset-bug.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { config } from 'dotenv';
-import { TestMCPClient } from '../../../../test-mcp-client/dist/index.js';
+import { TestMCPClient } from '../../../../test-mcp-client/build/index.js';
 import path from 'path';
 import { fileURLToPath } from 'url';
 

--- a/experimental/twist/tests/manual/test-robust-pagination.ts
+++ b/experimental/twist/tests/manual/test-robust-pagination.ts
@@ -1,5 +1,5 @@
 import { config } from 'dotenv';
-import { TestMCPClient } from '../../../../test-mcp-client/dist/index.js';
+import { TestMCPClient } from '../../../../test-mcp-client/build/index.js';
 import path from 'path';
 import { fileURLToPath } from 'url';
 

--- a/experimental/twist/tests/manual/twist.manual.test.ts
+++ b/experimental/twist/tests/manual/twist.manual.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { config } from 'dotenv';
-import { TestMCPClient } from '../../../../test-mcp-client/dist/index.js';
+import { TestMCPClient } from '../../../../test-mcp-client/build/index.js';
 import path from 'path';
 import { fileURLToPath } from 'url';
 

--- a/experimental/twist/tsconfig.json
+++ b/experimental/twist/tsconfig.json
@@ -3,7 +3,7 @@
     "target": "ES2022",
     "module": "Node16",
     "lib": ["ES2022"],
-    "outDir": "./dist",
+    "outDir": "./build",
     "rootDir": "./",
     "strict": true,
     "esModuleInterop": true,
@@ -15,5 +15,5 @@
     "noEmit": true
   },
   "include": ["**/*.ts"],
-  "exclude": ["node_modules", "**/dist/**", "**/build/**"]
+  "exclude": ["node_modules", "**/build/**"]
 }

--- a/experimental/twist/vitest.config.ts
+++ b/experimental/twist/vitest.config.ts
@@ -5,13 +5,7 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'node',
-    exclude: [
-      '**/node_modules/**',
-      '**/dist/**',
-      '**/build/**',
-      '**/integration/**',
-      '**/manual/**',
-    ],
+    exclude: ['**/node_modules/**', '**/build/**', '**/integration/**', '**/manual/**'],
   },
   resolve: {
     alias: {

--- a/mcp-server-template/.gitignore
+++ b/mcp-server-template/.gitignore
@@ -1,6 +1,5 @@
 node_modules/
 build/
-dist/
 .env
 .env.local
 .DS_Store

--- a/mcp-server-template/local/prepare-publish.js
+++ b/mcp-server-template/local/prepare-publish.js
@@ -56,7 +56,7 @@ async function prepare() {
   }
 
   // Copy the built shared files
-  await cp(join(__dirname, '../shared/dist'), join(__dirname, 'shared'), { recursive: true });
+  await cp(join(__dirname, '../shared/build'), join(__dirname, 'shared'), { recursive: true });
 
   console.log('Copied shared files to local package');
 }

--- a/mcp-server-template/local/setup-dev.js
+++ b/mcp-server-template/local/setup-dev.js
@@ -7,7 +7,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 
 async function setupDev() {
   const linkPath = join(__dirname, 'shared');
-  const targetPath = join(__dirname, '../shared/dist');
+  const targetPath = join(__dirname, '../shared/build');
 
   try {
     await unlink(linkPath);

--- a/mcp-server-template/package.json
+++ b/mcp-server-template/package.json
@@ -13,7 +13,7 @@
     "install-all": "npm install && cd local && npm install && cd ../shared && npm install",
     "build": "cd shared && npm run build && cd ../local && npm run build",
     "build:test": "cd shared && npm run build && cd ../local && npm run build && cd ../../../test-mcp-client && npm run build",
-    "clean": "find . -name '*.js' -not -path './node_modules/*' -not -path './*/node_modules/*' -not -path './local/build/*' -not -path './shared/dist/*' -not -path './*/dist/*' -not -path './*/build/*' -delete && find . -name '*.js.map' -not -path './node_modules/*' -not -path './*/node_modules/*' -not -path './local/build/*' -not -path './shared/dist/*' -not -path './*/dist/*' -not -path './*/build/*' -delete",
+    "clean": "find . -name '*.js' -not -path './node_modules/*' -not -path './*/node_modules/*' -not -path './local/build/*' -not -path './shared/build/*' -not -path './*/build/*' -delete && find . -name '*.js.map' -not -path './node_modules/*' -not -path './*/node_modules/*' -not -path './local/build/*' -not -path './shared/build/*' -not -path './*/build/*' -delete",
     "dev": "cd local && npm run dev",
     "test": "vitest",
     "test:ui": "vitest --ui",

--- a/mcp-server-template/shared/package.json
+++ b/mcp-server-template/shared/package.json
@@ -2,7 +2,7 @@
   "name": "NAME-mcp-server-shared",
   "version": "0.1.0",
   "description": "Shared code for NAME MCP server implementations",
-  "main": "dist/index.js",
+  "main": "build/index.js",
   "type": "module",
   "scripts": {
     "build": "tsc",

--- a/mcp-server-template/shared/tsconfig.json
+++ b/mcp-server-template/shared/tsconfig.json
@@ -8,11 +8,11 @@
     "skipLibCheck": true,
     "declaration": true,
     "declarationMap": true,
-    "outDir": "./dist",
+    "outDir": "./build",
     "rootDir": "./src",
     "lib": ["es2022"],
     "types": ["node"]
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "build"]
 }

--- a/mcp-server-template/tests/integration/NAME.integration.test.ts
+++ b/mcp-server-template/tests/integration/NAME.integration.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, afterEach } from 'vitest';
-import { TestMCPClient } from '../../../../test-mcp-client/dist/index.js';
+import { TestMCPClient } from '../../../../test-mcp-client/build/index.js';
 import { createIntegrationMockExampleClient } from '../../shared/src/example-client/example-client.integration-mock.js';
 import type { IExampleClient } from '../../shared/src/server.js';
 import path from 'path';

--- a/mcp-server-template/tsconfig.json
+++ b/mcp-server-template/tsconfig.json
@@ -3,7 +3,7 @@
     "target": "ES2022",
     "module": "Node16",
     "lib": ["ES2022"],
-    "outDir": "./dist",
+    "outDir": "./build",
     "rootDir": "./",
     "strict": true,
     "esModuleInterop": true,
@@ -15,5 +15,5 @@
     "noEmit": true
   },
   "include": ["**/*.ts"],
-  "exclude": ["node_modules", "**/dist/**", "**/build/**"]
+  "exclude": ["node_modules", "**/build/**"]
 }

--- a/mcp-server-template/vitest.config.ts
+++ b/mcp-server-template/vitest.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'node',
-    exclude: ['**/node_modules/**', '**/dist/**', '**/build/**', '**/integration/**'],
+    exclude: ['**/node_modules/**', '**/build/**', '**/integration/**'],
   },
   resolve: {
     alias: {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "lint": "eslint . --ext .ts,.tsx --max-warnings 0",
     "lint:fix": "eslint . --ext .ts,.tsx --fix",
     "format": "prettier --write .",
-    "format:check": "prettier --check ."
+    "format:check": "prettier --check .",
+    "clean": "rm -rf experimental/**/build experimental/**/dist productionized/**/build productionized/**/dist"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^8.19.0",

--- a/productionized/pulse-fetch/.eslintrc.json
+++ b/productionized/pulse-fetch/.eslintrc.json
@@ -3,5 +3,5 @@
   "parserOptions": {
     "project": true
   },
-  "ignorePatterns": ["**/*.js", "dist", "build"]
+  "ignorePatterns": ["**/*.js", "build"]
 }

--- a/productionized/pulse-fetch/local/prepare-publish.js
+++ b/productionized/pulse-fetch/local/prepare-publish.js
@@ -56,7 +56,7 @@ async function prepare() {
   }
 
   // Copy the built shared files
-  await cp(join(__dirname, '../shared/dist'), join(__dirname, 'shared'), { recursive: true });
+  await cp(join(__dirname, '../shared/build'), join(__dirname, 'shared'), { recursive: true });
 
   console.log('Copied shared files to local package');
 }

--- a/productionized/pulse-fetch/local/setup-dev.js
+++ b/productionized/pulse-fetch/local/setup-dev.js
@@ -7,7 +7,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 
 async function setupDev() {
   const linkPath = join(__dirname, 'shared');
-  const targetPath = join(__dirname, '../shared/dist');
+  const targetPath = join(__dirname, '../shared/build');
 
   try {
     await unlink(linkPath);

--- a/productionized/pulse-fetch/package.json
+++ b/productionized/pulse-fetch/package.json
@@ -14,7 +14,7 @@
     "ci:install": "npm ci && cd shared && npm ci && cd ../local && npm ci",
     "build": "cd shared && npm run build && cd ../local && npm run build",
     "build:test": "cd shared && npm run build && cd ../local && npm run build && cd ../../../test-mcp-client && npm run build",
-    "clean": "find . -name '*.js' -not -path './node_modules/*' -not -path './*/node_modules/*' -not -path './local/build/*' -not -path './shared/dist/*' -not -path './*/dist/*' -not -path './*/build/*' -delete && find . -name '*.js.map' -not -path './node_modules/*' -not -path './*/node_modules/*' -not -path './local/build/*' -not -path './shared/dist/*' -not -path './*/dist/*' -not -path './*/build/*' -delete",
+    "clean": "find . -name '*.js' -not -path './node_modules/*' -not -path './*/node_modules/*' -not -path './local/build/*' -not -path './shared/build/*' -not -path './*/build/*' -delete && find . -name '*.js.map' -not -path './node_modules/*' -not -path './*/node_modules/*' -not -path './local/build/*' -not -path './shared/build/*' -not -path './*/build/*' -delete",
     "dev": "cd local && npm run dev",
     "test": "node scripts/run-vitest.js",
     "test:ui": "node scripts/run-vitest.js --ui",

--- a/productionized/pulse-fetch/shared/package.json
+++ b/productionized/pulse-fetch/shared/package.json
@@ -2,7 +2,7 @@
   "name": "@pulsemcp/pulse-fetch-shared",
   "version": "0.0.1",
   "description": "Shared code for pulse-fetch MCP server implementations",
-  "main": "dist/index.js",
+  "main": "build/index.js",
   "type": "module",
   "scripts": {
     "build": "tsc",

--- a/productionized/pulse-fetch/shared/tsconfig.json
+++ b/productionized/pulse-fetch/shared/tsconfig.json
@@ -3,7 +3,7 @@
     "target": "ES2022",
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
-    "outDir": "./dist",
+    "outDir": "./build",
     "rootDir": "./src",
     "strict": true,
     "esModuleInterop": true,

--- a/productionized/pulse-fetch/tests/integration/test-runner.ts
+++ b/productionized/pulse-fetch/tests/integration/test-runner.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, afterEach, beforeAll } from 'vitest';
-import { TestMCPClient } from '../../../../test-mcp-client/dist/index.js';
+import { TestMCPClient } from '../../../../test-mcp-client/build/index.js';
 import { existsSync } from 'fs';
 
 interface MockConfig {

--- a/productionized/pulse-fetch/tests/mocks/scraping-clients.functional-mock.ts
+++ b/productionized/pulse-fetch/tests/mocks/scraping-clients.functional-mock.ts
@@ -3,7 +3,7 @@ import type {
   IFirecrawlClient,
   IBrightDataClient,
   IScrapingClients,
-} from '../../shared/dist/server.js';
+} from '../../shared/build/server.js';
 
 export interface MockNativeFetcher extends INativeFetcher {
   setMockResponse(response: {

--- a/productionized/pulse-fetch/tsconfig.json
+++ b/productionized/pulse-fetch/tsconfig.json
@@ -3,7 +3,7 @@
     "target": "ES2022",
     "module": "Node16",
     "lib": ["ES2022"],
-    "outDir": "./dist",
+    "outDir": "./build",
     "rootDir": "./",
     "strict": true,
     "esModuleInterop": true,
@@ -15,5 +15,5 @@
     "noEmit": true
   },
   "include": ["**/*.ts"],
-  "exclude": ["node_modules", "**/dist/**", "**/build/**"]
+  "exclude": ["node_modules", "**/build/**"]
 }

--- a/productionized/pulse-fetch/vitest.config.ts
+++ b/productionized/pulse-fetch/vitest.config.ts
@@ -5,13 +5,7 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'node',
-    exclude: [
-      '**/node_modules/**',
-      '**/dist/**',
-      '**/build/**',
-      '**/integration/**',
-      '**/manual/**',
-    ],
+    exclude: ['**/node_modules/**', '**/build/**', '**/integration/**', '**/manual/**'],
   },
   resolve: {
     alias: {

--- a/test-mcp-client/.gitignore
+++ b/test-mcp-client/.gitignore
@@ -2,7 +2,6 @@
 node_modules/
 
 # Build output
-dist/
 
 # TypeScript compiled files in source directories
 src/**/*.js

--- a/test-mcp-client/package.json
+++ b/test-mcp-client/package.json
@@ -3,8 +3,8 @@
   "version": "1.0.0",
   "description": "Test client for MCP servers - drives integration tests via stdio transport",
   "type": "module",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "scripts": {
     "build": "tsc",
     "dev": "tsx src/index.ts",

--- a/test-mcp-client/tsconfig.json
+++ b/test-mcp-client/tsconfig.json
@@ -3,7 +3,7 @@
     "target": "ES2022",
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
-    "outDir": "./dist",
+    "outDir": "./build",
     "rootDir": "./src",
     "declaration": true,
     "strict": true,
@@ -13,5 +13,5 @@
     "resolveJsonModule": true
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "build"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,5 +12,5 @@
     "allowJs": false,
     "noEmit": true
   },
-  "exclude": ["node_modules", "**/node_modules", "dist", "build", "**/dist", "**/build"]
+  "exclude": ["node_modules", "**/node_modules", "build", "**/build"]
 }


### PR DESCRIPTION
## Summary

- Replace all `dist` directory references with `build` across all MCP servers
- Add root-level `clean` npm script that removes all build artifacts using glob patterns
- Standardize TypeScript output directory naming convention for consistency

## Changes

1. **Updated all tsconfig.json files** to use `"outDir": "./build"`
2. **Cleaned up .gitignore files** by removing redundant `dist` entries (since `build` was already present)
3. **Updated package.json files** to change `"main"` fields from `"dist/index.js"` to `"build/index.js"`
4. **Modified all setup and publish scripts** to reference build directories instead of dist
5. **Updated import paths in test files** to use the new build directory
6. **Added concise clean script** in root package.json: `rm -rf experimental/**/build experimental/**/dist productionized/**/build productionized/**/dist`

## Test plan

- [ ] Verify all MCP servers build successfully with new build directory
- [ ] Ensure clean script removes all build artifacts
- [ ] Confirm integration tests pass with updated import paths
- [ ] Check that development setup scripts work correctly

🤖 Generated with [Claude Code](https://claude.ai/code)