### PR TITLE
fix(pulse-fetch): fix overly aggressive caching that ignored extract parameter

### DIFF
--- a/productionized/pulse-fetch/CHANGELOG.md
+++ b/productionized/pulse-fetch/CHANGELOG.md
@@ -13,6 +13,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Resources now properly detect content type based on actual content (text/html, application/json, application/xml, text/plain)
   - Previously all resources were incorrectly marked as text/plain regardless of content
   - Added comprehensive functional tests for MIME type detection
+- Fixed overly aggressive caching that ignored the `extract` parameter
+  - Cache lookups now consider both URL and extract prompt when finding cached resources
+  - Different extraction queries on the same URL will no longer return incorrect cached results
+  - Added new `findByUrlAndExtract` method to storage interfaces for proper cache key generation
+  - Added comprehensive test coverage for extract field cache busting functionality
 
 ## [0.2.7] - 2025-07-03
 

--- a/productionized/pulse-fetch/shared/src/storage/memory.ts
+++ b/productionized/pulse-fetch/shared/src/storage/memory.ts
@@ -114,6 +114,28 @@ export class MemoryResourceStorage implements ResourceStorage {
     return matchingResources;
   }
 
+  async findByUrlAndExtract(url: string, extractPrompt?: string): Promise<ResourceData[]> {
+    const matchingResources = Array.from(this.resources.values())
+      .filter((r) => {
+        const matchesUrl = r.data.metadata.url === url;
+        if (!extractPrompt) {
+          // If no extract prompt specified, only return resources without extraction
+          return matchesUrl && !r.data.metadata.extractionPrompt;
+        }
+        // If extract prompt specified, match both URL and extraction prompt
+        return matchesUrl && r.data.metadata.extractionPrompt === extractPrompt;
+      })
+      .sort((a, b) => {
+        // Sort by timestamp descending (most recent first)
+        const timeA = new Date(a.data.metadata.timestamp).getTime();
+        const timeB = new Date(b.data.metadata.timestamp).getTime();
+        return timeB - timeA;
+      })
+      .map((r) => r.data);
+
+    return matchingResources;
+  }
+
   private generateUri(url: string, timestamp: string, resourceType: ResourceType = 'raw'): string {
     const sanitizedUrl = url.replace(/^https?:\/\//, '').replace(/[^a-zA-Z0-9.-]/g, '_');
     const timestampPart = timestamp.replace(/[^0-9]/g, '');

--- a/productionized/pulse-fetch/shared/src/storage/types.ts
+++ b/productionized/pulse-fetch/shared/src/storage/types.ts
@@ -48,4 +48,5 @@ export interface ResourceStorage {
   exists(uri: string): Promise<boolean>;
   delete(uri: string): Promise<void>;
   findByUrl(url: string): Promise<ResourceData[]>;
+  findByUrlAndExtract(url: string, extractPrompt?: string): Promise<ResourceData[]>;
 }

--- a/productionized/pulse-fetch/shared/src/tools/scrape.ts
+++ b/productionized/pulse-fetch/shared/src/tools/scrape.ts
@@ -254,7 +254,7 @@ Use cases:
         if (!forceRescrape) {
           try {
             const storage = await ResourceStorageFactory.create();
-            const cachedResources = await storage.findByUrl(url);
+            const cachedResources = await storage.findByUrlAndExtract(url, extract);
 
             if (cachedResources.length > 0) {
               // Use the most recent cached resource (already sorted by timestamp desc)

--- a/productionized/pulse-fetch/tests/functional/cache-extract.test.ts
+++ b/productionized/pulse-fetch/tests/functional/cache-extract.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { MemoryResourceStorage } from '../../shared/src/storage/memory.js';
+import { FileSystemResourceStorage } from '../../shared/src/storage/filesystem.js';
+import { join } from 'path';
+import { mkdtemp, rm } from 'fs/promises';
+import { tmpdir } from 'os';
+
+describe('Storage findByUrlAndExtract', () => {
+  describe('MemoryResourceStorage', () => {
+    let storage: MemoryResourceStorage;
+
+    beforeEach(() => {
+      storage = new MemoryResourceStorage();
+    });
+
+    it('should find resources by URL and extract prompt', async () => {
+      const url = 'https://example.com/test';
+
+      // Write resources with different extract prompts
+      await storage.writeMulti({
+        url,
+        raw: '<html><body>Raw content</body></html>',
+        cleaned: 'Cleaned content',
+        extracted: 'Title: Test Page',
+        metadata: {
+          extract: 'get the title',
+        },
+      });
+
+      // Add delay to ensure different timestamps
+      await new Promise((resolve) => setTimeout(resolve, 2));
+
+      await storage.writeMulti({
+        url,
+        raw: '<html><body>Raw content</body></html>',
+        cleaned: 'Cleaned content',
+        extracted: 'Email: test@example.com',
+        metadata: {
+          extract: 'find emails',
+        },
+      });
+
+      // Add delay to ensure different timestamps
+      await new Promise((resolve) => setTimeout(resolve, 2));
+
+      await storage.writeMulti({
+        url,
+        raw: '<html><body>Raw content</body></html>',
+        cleaned: 'Cleaned content without extraction',
+      });
+
+      // Test finding by URL and specific extract prompt
+      const titleResources = await storage.findByUrlAndExtract(url, 'get the title');
+      expect(titleResources).toHaveLength(1);
+      expect(titleResources[0].metadata.extractionPrompt).toBe('get the title');
+
+      const emailResources = await storage.findByUrlAndExtract(url, 'find emails');
+      expect(emailResources).toHaveLength(1);
+      expect(emailResources[0].metadata.extractionPrompt).toBe('find emails');
+
+      // Test finding resources without extraction
+      const noExtractResources = await storage.findByUrlAndExtract(url);
+      // Should find resources without extractionPrompt
+      expect(noExtractResources.length).toBeGreaterThan(0);
+      expect(noExtractResources.every((r) => !r.metadata.extractionPrompt)).toBe(true);
+
+      // Test no matches for non-existent extract prompt
+      const noMatches = await storage.findByUrlAndExtract(url, 'non-existent prompt');
+      expect(noMatches).toHaveLength(0);
+    });
+
+    it('should return most recent resource when multiple exist for same extract', async () => {
+      const url = 'https://example.com/test-order';
+
+      // Add slight delays to ensure different timestamps
+      await storage.writeMulti({
+        url,
+        raw: 'raw1',
+        extracted: 'Old extraction',
+        metadata: { extract: 'test query' },
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 1));
+
+      await storage.writeMulti({
+        url,
+        raw: 'raw2',
+        extracted: 'New extraction',
+        metadata: { extract: 'test query' },
+      });
+
+      const resources = await storage.findByUrlAndExtract(url, 'test query');
+      expect(resources).toHaveLength(2);
+      // Most recent should be first
+      const content = await storage.read(resources[0].uri);
+      expect(content.text).toBe('New extraction');
+    });
+  });
+
+  describe('FileSystemResourceStorage', () => {
+    let storage: FileSystemResourceStorage;
+    let tempDir: string;
+
+    beforeEach(async () => {
+      tempDir = await mkdtemp(join(tmpdir(), 'pulse-fetch-test-'));
+      storage = new FileSystemResourceStorage(tempDir);
+    });
+
+    afterEach(async () => {
+      await rm(tempDir, { recursive: true, force: true });
+    });
+
+    it('should find resources by URL and extract prompt', async () => {
+      const url = 'https://example.com/filesystem-test';
+
+      // Write resources with different extract prompts
+      await storage.writeMulti({
+        url,
+        raw: '<html><body>Raw content</body></html>',
+        cleaned: 'Cleaned content',
+        extracted: 'Title: Test Page',
+        metadata: {
+          extract: 'get the title',
+        },
+      });
+
+      // Add delay to ensure different timestamps
+      await new Promise((resolve) => setTimeout(resolve, 2));
+
+      await storage.writeMulti({
+        url,
+        raw: '<html><body>Raw content</body></html>',
+        cleaned: 'Cleaned content',
+        extracted: 'Email: test@example.com',
+        metadata: {
+          extract: 'find emails',
+        },
+      });
+
+      // Add delay to ensure different timestamps
+      await new Promise((resolve) => setTimeout(resolve, 2));
+
+      await storage.writeMulti({
+        url,
+        raw: '<html><body>Raw content</body></html>',
+        cleaned: 'Cleaned content without extraction',
+      });
+
+      // Test finding by URL and specific extract prompt
+      const titleResources = await storage.findByUrlAndExtract(url, 'get the title');
+      expect(titleResources).toHaveLength(1);
+      expect(titleResources[0].metadata.extractionPrompt).toBe('get the title');
+
+      const emailResources = await storage.findByUrlAndExtract(url, 'find emails');
+      expect(emailResources).toHaveLength(1);
+      expect(emailResources[0].metadata.extractionPrompt).toBe('find emails');
+
+      // Test finding resources without extraction
+      const noExtractResources = await storage.findByUrlAndExtract(url);
+      // Should find raw and cleaned resources (not extracted)
+      const types = noExtractResources.map((r) => r.metadata.resourceType);
+      expect(types).toContain('raw');
+      expect(types).toContain('cleaned');
+      expect(types).not.toContain('extracted');
+      expect(noExtractResources.every((r) => !r.metadata.extractionPrompt)).toBe(true);
+
+      // Test no matches for non-existent extract prompt
+      const noMatches = await storage.findByUrlAndExtract(url, 'non-existent prompt');
+      expect(noMatches).toHaveLength(0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Fixed overly aggressive caching that ignored the `extract` parameter when looking up cached resources
- Added new `findByUrlAndExtract` method to storage interfaces for proper cache consideration
- Different extraction queries on the same URL now create separate cache entries as expected

## Problem

When using the scrape tool with different `extract` parameters on the same URL, the cache would return the first cached result regardless of the extraction query. For example:
1. Scrape CNN.com with `extract: "get the title"`
2. Scrape CNN.com with `extract: "find all email addresses"`
3. The second request would incorrectly return the cached title result

## Solution

- Updated cache lookup logic to consider both URL and extract prompt
- Resources without extraction are cached separately from extracted resources
- Each unique extract prompt creates its own cache entry

## Test Coverage

Added comprehensive functional tests verifying:
- Different extract prompts create separate cache entries
- Same extract prompts reuse cached content
- Resources without extraction are cached separately
- Both MemoryResourceStorage and FileSystemResourceStorage implementations

## Breaking Changes

None - this is a bug fix that makes caching work as expected.