### PR TITLE
refactor: make tool parameter descriptions DRY across all MCP servers

### DIFF
--- a/.claude/commands/publish_and_pr.md
+++ b/.claude/commands/publish_and_pr.md
@@ -4,7 +4,8 @@ We are doing a version bump of type (major/minor/patch): $ARGUMENTS
 
 I want you to:
 
-- [ ] **CRITICAL FIRST STEP**: Before starting, run `git status` to see current state
+- [ ] Before you start, make sure you have recently run the `manual` test suites (with valid secrets in place - you can usually find them in a .env file within the MCP server source) and proven the happen path is working. We don't want to accidentally publish a version bump that fails manual tests.
+- [ ] Before starting, run `git status` to see current state
 - [ ] Run the publication process for server updates ([PUBLISHING_SERVERS.md](../../docs/PUBLISHING_SERVERS.md))
 - [ ] **IMMEDIATELY AFTER VERSION BUMP**: Run `git status` to see ALL files modified by npm version command
 - [ ] **BEFORE ANY COMMITS**: Ensure ALL files from the version bump are staged (package.json, package-lock.json, CHANGELOG.md, README.md, etc.)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -359,9 +359,3 @@ Don't add: basic TypeScript fixes, standard npm troubleshooting, obvious file op
 ### Changelog management
 
 Whenever you make any sort of code change to an MCP server, make sure to update the unreleased section of its corresponding `CHANGELOG.md`.
-
-### MCP Tool Definition Patterns
-
-- **Tool Registration Duality**: MCP servers can use either `server.tool()` or the newer pattern of returning tool definition objects from tool functions. When modernizing tools, ensure consistency between the tool functions and how they're registered in tools.ts
-- **InputSchema Types**: When using `server.tool()`, the inputSchema parameter expects a ZodRawShape (object with Zod schemas as values), not a full ZodObject. Define shapes separately: `const MyShape = { field: z.string() }` then use `z.object(MyShape)` for validation
-- **Functional vs Integration Test Patterns**: Functional tests may mock the server object differently than how the actual MCP SDK works. Tool functions that work with the real SDK may need adjustments for test compatibility

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -359,3 +359,9 @@ Don't add: basic TypeScript fixes, standard npm troubleshooting, obvious file op
 ### Changelog management
 
 Whenever you make any sort of code change to an MCP server, make sure to update the unreleased section of its corresponding `CHANGELOG.md`.
+
+### MCP Tool Definition Patterns
+
+- **Tool Registration Duality**: MCP servers can use either `server.tool()` or the newer pattern of returning tool definition objects from tool functions. When modernizing tools, ensure consistency between the tool functions and how they're registered in tools.ts
+- **InputSchema Types**: When using `server.tool()`, the inputSchema parameter expects a ZodRawShape (object with Zod schemas as values), not a full ZodObject. Define shapes separately: `const MyShape = { field: z.string() }` then use `z.object(MyShape)` for validation
+- **Functional vs Integration Test Patterns**: Functional tests may mock the server object differently than how the actual MCP SDK works. Tool functions that work with the real SDK may need adjustments for test compatibility

--- a/experimental/appsignal/CHANGELOG.md
+++ b/experimental/appsignal/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Added `PARAM_DESCRIPTIONS` constants to maintain single source of truth
   - All 14 tool files now follow consistent modern pattern
   - Improves maintainability and type safety with better tool configuration objects
+- Updated all tools to use JSON Schema format for `inputSchema` instead of passing Zod schemas directly
+  - This aligns with MCP SDK best practices for tool registration
+  - Handler functions now accept `args: unknown` and parse with Zod schemas for validation
+  - Added TypeScript type assertions to satisfy compiler requirements
 
 ## [0.2.10] - 2025-07-03
 

--- a/experimental/appsignal/CHANGELOG.md
+++ b/experimental/appsignal/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Modernized all tools to use `McpServer.registerTool()` instead of deprecated `server.tool()` method
+- Applied DRY (Don't Repeat Yourself) pattern to all tool parameter descriptions
+  - Added `PARAM_DESCRIPTIONS` constants to maintain single source of truth
+  - All 14 tool files now follow consistent modern pattern
+  - Improves maintainability and type safety with better tool configuration objects
+
 ## [0.2.10] - 2025-07-03
 
 ### Added

--- a/experimental/appsignal/CHANGELOG.md
+++ b/experimental/appsignal/CHANGELOG.md
@@ -14,10 +14,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Added `PARAM_DESCRIPTIONS` constants to maintain single source of truth
   - All 14 tool files now follow consistent modern pattern
   - Improves maintainability and type safety with better tool configuration objects
-- Updated all tools to use JSON Schema format for `inputSchema` instead of passing Zod schemas directly
-  - This aligns with MCP SDK best practices for tool registration
-  - Handler functions now accept `args: unknown` and parse with Zod schemas for validation
-  - Added TypeScript type assertions to satisfy compiler requirements
 
 ## [0.2.10] - 2025-07-03
 

--- a/experimental/appsignal/CHANGELOG.md
+++ b/experimental/appsignal/CHANGELOG.md
@@ -9,11 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Modernized all tools to use `McpServer.registerTool()` instead of deprecated `server.tool()` method
 - Applied DRY (Don't Repeat Yourself) pattern to all tool parameter descriptions
   - Added `PARAM_DESCRIPTIONS` constants to maintain single source of truth
-  - All 14 tool files now follow consistent modern pattern
-  - Improves maintainability and type safety with better tool configuration objects
+  - All 14 tool files now use consistent parameter descriptions
+  - Separated Zod shape definitions from schema objects for better organization
+  - Improves maintainability by eliminating description duplication
 
 ## [0.2.10] - 2025-07-03
 

--- a/experimental/appsignal/shared/src/tools/get-anomaly-incident.ts
+++ b/experimental/appsignal/shared/src/tools/get-anomaly-incident.ts
@@ -39,25 +39,15 @@ Use cases:
 - Getting detailed metrics about unusual application behavior
 - Understanding the scope and impact of detected anomalies
 - Tracking the resolution status of performance issues`,
-      inputSchema: {
-        type: 'object',
-        properties: {
-          incidentNumber: {
-            type: 'string',
-            description: PARAM_DESCRIPTIONS.incidentNumber,
-          },
-        },
-        required: ['incidentNumber'],
-      } as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+      inputSchema: GetAnomalyIncidentSchema,
     },
-    async (args: unknown) => {
-      const { incidentNumber } = GetAnomalyIncidentSchema.parse(args);
+    async ({ incidentNumber }) => {
       const appId = getEffectiveAppId();
       if (!appId) {
         return {
           content: [
             {
-              type: 'text' as const,
+              type: 'text',
               text: 'Error: No app ID configured. Please use select_app_id tool first or set APPSIGNAL_APP_ID environment variable.',
             },
           ],
@@ -71,7 +61,7 @@ Use cases:
         return {
           content: [
             {
-              type: 'text' as const,
+              type: 'text',
               text: JSON.stringify(incident, null, 2),
             },
           ],
@@ -80,7 +70,7 @@ Use cases:
         return {
           content: [
             {
-              type: 'text' as const,
+              type: 'text',
               text: `Error fetching anomaly incident details: ${error instanceof Error ? error.message : 'Unknown error'}`,
             },
           ],

--- a/experimental/appsignal/shared/src/tools/get-anomaly-incident.ts
+++ b/experimental/appsignal/shared/src/tools/get-anomaly-incident.ts
@@ -8,18 +8,16 @@ const PARAM_DESCRIPTIONS = {
   incidentNumber: 'The unique number of the anomaly incident to retrieve',
 } as const;
 
-export function getAnomalyIncidentTool(server: McpServer, clientFactory: () => IAppsignalClient) {
+export function getAnomalyIncidentTool(_server: McpServer, clientFactory: () => IAppsignalClient) {
   const GetAnomalyIncidentShape = {
     incidentNumber: z.string().describe(PARAM_DESCRIPTIONS.incidentNumber),
   };
 
   const GetAnomalyIncidentSchema = z.object(GetAnomalyIncidentShape);
 
-  return server.registerTool(
-    'get_anomaly_incident',
-    {
-      title: 'Get Anomaly Incident',
-      description: `Retrieve detailed information about a specific anomaly incident in your AppSignal application. Anomaly incidents are automatically detected unusual patterns in your application's performance metrics, such as abnormal response times, memory usage spikes, or throughput variations. This tool provides comprehensive details about a single anomaly, including when it was detected, its severity, affected metrics, and current status.
+  return {
+    name: 'get_anomaly_incident',
+    description: `Retrieve detailed information about a specific anomaly incident in your AppSignal application. Anomaly incidents are automatically detected unusual patterns in your application's performance metrics, such as abnormal response times, memory usage spikes, or throughput variations. This tool provides comprehensive details about a single anomaly, including when it was detected, its severity, affected metrics, and current status.
 
 Example response:
 {
@@ -41,16 +39,15 @@ Use cases:
 - Getting detailed metrics about unusual application behavior
 - Understanding the scope and impact of detected anomalies
 - Tracking the resolution status of performance issues`,
-      inputSchema: GetAnomalyIncidentShape,
-    },
-    async (args) => {
+    inputSchema: GetAnomalyIncidentShape,
+    handler: async (args: unknown) => {
       const { incidentNumber } = GetAnomalyIncidentSchema.parse(args);
       const appId = getEffectiveAppId();
       if (!appId) {
         return {
           content: [
             {
-              type: 'text',
+              type: 'text' as const,
               text: 'Error: No app ID configured. Please use select_app_id tool first or set APPSIGNAL_APP_ID environment variable.',
             },
           ],
@@ -64,7 +61,7 @@ Use cases:
         return {
           content: [
             {
-              type: 'text',
+              type: 'text' as const,
               text: JSON.stringify(incident, null, 2),
             },
           ],
@@ -73,12 +70,12 @@ Use cases:
         return {
           content: [
             {
-              type: 'text',
+              type: 'text' as const,
               text: `Error fetching anomaly incident details: ${error instanceof Error ? error.message : 'Unknown error'}`,
             },
           ],
         };
       }
-    }
-  );
+    },
+  };
 }

--- a/experimental/appsignal/shared/src/tools/get-anomaly-incident.ts
+++ b/experimental/appsignal/shared/src/tools/get-anomaly-incident.ts
@@ -9,9 +9,11 @@ const PARAM_DESCRIPTIONS = {
 } as const;
 
 export function getAnomalyIncidentTool(server: McpServer, clientFactory: () => IAppsignalClient) {
-  const GetAnomalyIncidentSchema = z.object({
+  const GetAnomalyIncidentShape = {
     incidentNumber: z.string().describe(PARAM_DESCRIPTIONS.incidentNumber),
-  });
+  };
+
+  const GetAnomalyIncidentSchema = z.object(GetAnomalyIncidentShape);
 
   return server.registerTool(
     'get_anomaly_incident',
@@ -39,9 +41,10 @@ Use cases:
 - Getting detailed metrics about unusual application behavior
 - Understanding the scope and impact of detected anomalies
 - Tracking the resolution status of performance issues`,
-      inputSchema: GetAnomalyIncidentSchema,
+      inputSchema: GetAnomalyIncidentShape,
     },
-    async ({ incidentNumber }) => {
+    async (args) => {
+      const { incidentNumber } = GetAnomalyIncidentSchema.parse(args);
       const appId = getEffectiveAppId();
       if (!appId) {
         return {

--- a/experimental/appsignal/shared/src/tools/get-anomaly-incident.ts
+++ b/experimental/appsignal/shared/src/tools/get-anomaly-incident.ts
@@ -39,15 +39,25 @@ Use cases:
 - Getting detailed metrics about unusual application behavior
 - Understanding the scope and impact of detected anomalies
 - Tracking the resolution status of performance issues`,
-      inputSchema: GetAnomalyIncidentSchema,
+      inputSchema: {
+        type: 'object',
+        properties: {
+          incidentNumber: {
+            type: 'string',
+            description: PARAM_DESCRIPTIONS.incidentNumber,
+          },
+        },
+        required: ['incidentNumber'],
+      } as any, // eslint-disable-line @typescript-eslint/no-explicit-any
     },
-    async ({ incidentNumber }) => {
+    async (args: unknown) => {
+      const { incidentNumber } = GetAnomalyIncidentSchema.parse(args);
       const appId = getEffectiveAppId();
       if (!appId) {
         return {
           content: [
             {
-              type: 'text',
+              type: 'text' as const,
               text: 'Error: No app ID configured. Please use select_app_id tool first or set APPSIGNAL_APP_ID environment variable.',
             },
           ],
@@ -61,7 +71,7 @@ Use cases:
         return {
           content: [
             {
-              type: 'text',
+              type: 'text' as const,
               text: JSON.stringify(incident, null, 2),
             },
           ],
@@ -70,7 +80,7 @@ Use cases:
         return {
           content: [
             {
-              type: 'text',
+              type: 'text' as const,
               text: `Error fetching anomaly incident details: ${error instanceof Error ? error.message : 'Unknown error'}`,
             },
           ],

--- a/experimental/appsignal/shared/src/tools/get-anomaly-incident.ts
+++ b/experimental/appsignal/shared/src/tools/get-anomaly-incident.ts
@@ -3,10 +3,21 @@ import { z } from 'zod';
 import { getEffectiveAppId } from '../state.js';
 import { IAppsignalClient } from '../appsignal-client/appsignal-client.js';
 
+// Parameter descriptions - single source of truth
+const PARAM_DESCRIPTIONS = {
+  incidentNumber: 'The unique number of the anomaly incident to retrieve',
+} as const;
+
 export function getAnomalyIncidentTool(server: McpServer, clientFactory: () => IAppsignalClient) {
-  return server.tool(
+  const GetAnomalyIncidentSchema = z.object({
+    incidentNumber: z.string().describe(PARAM_DESCRIPTIONS.incidentNumber),
+  });
+
+  return server.registerTool(
     'get_anomaly_incident',
-    `Retrieve detailed information about a specific anomaly incident in your AppSignal application. Anomaly incidents are automatically detected unusual patterns in your application's performance metrics, such as abnormal response times, memory usage spikes, or throughput variations. This tool provides comprehensive details about a single anomaly, including when it was detected, its severity, affected metrics, and current status.
+    {
+      title: 'Get Anomaly Incident',
+      description: `Retrieve detailed information about a specific anomaly incident in your AppSignal application. Anomaly incidents are automatically detected unusual patterns in your application's performance metrics, such as abnormal response times, memory usage spikes, or throughput variations. This tool provides comprehensive details about a single anomaly, including when it was detected, its severity, affected metrics, and current status.
 
 Example response:
 {
@@ -28,8 +39,7 @@ Use cases:
 - Getting detailed metrics about unusual application behavior
 - Understanding the scope and impact of detected anomalies
 - Tracking the resolution status of performance issues`,
-    {
-      incidentNumber: z.string().describe('The unique number of the anomaly incident to retrieve'),
+      inputSchema: GetAnomalyIncidentSchema,
     },
     async ({ incidentNumber }) => {
       const appId = getEffectiveAppId();

--- a/experimental/appsignal/shared/src/tools/get-anomaly-incidents.ts
+++ b/experimental/appsignal/shared/src/tools/get-anomaly-incidents.ts
@@ -65,38 +65,17 @@ Use cases:
 - Reviewing historical anomaly patterns
 - Identifying trends in application performance issues
 - Prioritizing performance optimization efforts`,
-      inputSchema: {
-        type: 'object',
-        properties: {
-          states: {
-            type: 'array',
-            items: {
-              type: 'string',
-              enum: ['OPEN', 'CLOSED', 'WIP'],
-            },
-            description: PARAM_DESCRIPTIONS.states,
-          },
-          limit: {
-            type: 'number',
-            description: PARAM_DESCRIPTIONS.limit,
-          },
-          offset: {
-            type: 'number',
-            description: PARAM_DESCRIPTIONS.offset,
-          },
-        },
-        required: [],
-      } as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+      inputSchema: GetAnomalyIncidentsSchema,
     },
-    async (args: unknown) => {
+    async (args) => {
       // Handle all parameter scenarios: {}, undefined, or missing entirely
-      const { states, limit, offset } = GetAnomalyIncidentsSchema.parse(args || {});
+      const { states, limit, offset } = args || {};
       const appId = getEffectiveAppId();
       if (!appId) {
         return {
           content: [
             {
-              type: 'text' as const,
+              type: 'text',
               text: 'Error: No app ID configured. Please use select_app_id tool first or set APPSIGNAL_APP_ID environment variable.',
             },
           ],
@@ -115,7 +94,7 @@ Use cases:
         return {
           content: [
             {
-              type: 'text' as const,
+              type: 'text',
               text: JSON.stringify(result, null, 2),
             },
           ],
@@ -124,7 +103,7 @@ Use cases:
         return {
           content: [
             {
-              type: 'text' as const,
+              type: 'text',
               text: `Error fetching anomaly incidents: ${error instanceof Error ? error.message : 'Unknown error'}`,
             },
           ],

--- a/experimental/appsignal/shared/src/tools/get-anomaly-incidents.ts
+++ b/experimental/appsignal/shared/src/tools/get-anomaly-incidents.ts
@@ -65,17 +65,38 @@ Use cases:
 - Reviewing historical anomaly patterns
 - Identifying trends in application performance issues
 - Prioritizing performance optimization efforts`,
-      inputSchema: GetAnomalyIncidentsSchema,
+      inputSchema: {
+        type: 'object',
+        properties: {
+          states: {
+            type: 'array',
+            items: {
+              type: 'string',
+              enum: ['OPEN', 'CLOSED', 'WIP'],
+            },
+            description: PARAM_DESCRIPTIONS.states,
+          },
+          limit: {
+            type: 'number',
+            description: PARAM_DESCRIPTIONS.limit,
+          },
+          offset: {
+            type: 'number',
+            description: PARAM_DESCRIPTIONS.offset,
+          },
+        },
+        required: [],
+      } as any, // eslint-disable-line @typescript-eslint/no-explicit-any
     },
-    async (args) => {
+    async (args: unknown) => {
       // Handle all parameter scenarios: {}, undefined, or missing entirely
-      const { states, limit, offset } = args || {};
+      const { states, limit, offset } = GetAnomalyIncidentsSchema.parse(args || {});
       const appId = getEffectiveAppId();
       if (!appId) {
         return {
           content: [
             {
-              type: 'text',
+              type: 'text' as const,
               text: 'Error: No app ID configured. Please use select_app_id tool first or set APPSIGNAL_APP_ID environment variable.',
             },
           ],
@@ -94,7 +115,7 @@ Use cases:
         return {
           content: [
             {
-              type: 'text',
+              type: 'text' as const,
               text: JSON.stringify(result, null, 2),
             },
           ],
@@ -103,7 +124,7 @@ Use cases:
         return {
           content: [
             {
-              type: 'text',
+              type: 'text' as const,
               text: `Error fetching anomaly incidents: ${error instanceof Error ? error.message : 'Unknown error'}`,
             },
           ],

--- a/experimental/appsignal/shared/src/tools/get-anomaly-incidents.ts
+++ b/experimental/appsignal/shared/src/tools/get-anomaly-incidents.ts
@@ -11,7 +11,7 @@ const PARAM_DESCRIPTIONS = {
   offset: 'Number of incidents to skip for pagination. Defaults to 0',
 } as const;
 
-export function getAnomalyIncidentsTool(server: McpServer, clientFactory: () => IAppsignalClient) {
+export function getAnomalyIncidentsTool(_server: McpServer, clientFactory: () => IAppsignalClient) {
   const GetAnomalyIncidentsShape = {
     states: z
       .array(z.enum(['OPEN', 'CLOSED', 'WIP']))
@@ -23,11 +23,9 @@ export function getAnomalyIncidentsTool(server: McpServer, clientFactory: () => 
 
   const GetAnomalyIncidentsSchema = z.object(GetAnomalyIncidentsShape);
 
-  return server.registerTool(
-    'get_anomaly_incidents',
-    {
-      title: 'Get Anomaly Incidents',
-      description: `Retrieve a list of anomaly incidents detected by AppSignal's automatic performance monitoring. Anomaly incidents represent unusual patterns in your application's behavior, such as response time spikes, memory usage anomalies, or throughput variations. This tool allows filtering by incident state and supports pagination for large result sets.
+  return {
+    name: 'get_anomaly_incidents',
+    description: `Retrieve a list of anomaly incidents detected by AppSignal's automatic performance monitoring. Anomaly incidents represent unusual patterns in your application's behavior, such as response time spikes, memory usage anomalies, or throughput variations. This tool allows filtering by incident state and supports pagination for large result sets.
 
 Example response:
 {
@@ -67,9 +65,8 @@ Use cases:
 - Reviewing historical anomaly patterns
 - Identifying trends in application performance issues
 - Prioritizing performance optimization efforts`,
-      inputSchema: GetAnomalyIncidentsShape,
-    },
-    async (args) => {
+    inputSchema: GetAnomalyIncidentsShape,
+    handler: async (args: unknown) => {
       // Handle all parameter scenarios: {}, undefined, or missing entirely
       const { states, limit, offset } = GetAnomalyIncidentsSchema.parse(args || {});
       const appId = getEffectiveAppId();
@@ -77,7 +74,7 @@ Use cases:
         return {
           content: [
             {
-              type: 'text',
+              type: 'text' as const,
               text: 'Error: No app ID configured. Please use select_app_id tool first or set APPSIGNAL_APP_ID environment variable.',
             },
           ],
@@ -96,7 +93,7 @@ Use cases:
         return {
           content: [
             {
-              type: 'text',
+              type: 'text' as const,
               text: JSON.stringify(result, null, 2),
             },
           ],
@@ -105,12 +102,12 @@ Use cases:
         return {
           content: [
             {
-              type: 'text',
+              type: 'text' as const,
               text: `Error fetching anomaly incidents: ${error instanceof Error ? error.message : 'Unknown error'}`,
             },
           ],
         };
       }
-    }
-  );
+    },
+  };
 }

--- a/experimental/appsignal/shared/src/tools/get-anomaly-incidents.ts
+++ b/experimental/appsignal/shared/src/tools/get-anomaly-incidents.ts
@@ -12,14 +12,16 @@ const PARAM_DESCRIPTIONS = {
 } as const;
 
 export function getAnomalyIncidentsTool(server: McpServer, clientFactory: () => IAppsignalClient) {
-  const GetAnomalyIncidentsSchema = z.object({
+  const GetAnomalyIncidentsShape = {
     states: z
       .array(z.enum(['OPEN', 'CLOSED', 'WIP']))
       .optional()
       .describe(PARAM_DESCRIPTIONS.states),
     limit: z.number().optional().describe(PARAM_DESCRIPTIONS.limit),
     offset: z.number().optional().describe(PARAM_DESCRIPTIONS.offset),
-  });
+  };
+
+  const GetAnomalyIncidentsSchema = z.object(GetAnomalyIncidentsShape);
 
   return server.registerTool(
     'get_anomaly_incidents',
@@ -65,11 +67,11 @@ Use cases:
 - Reviewing historical anomaly patterns
 - Identifying trends in application performance issues
 - Prioritizing performance optimization efforts`,
-      inputSchema: GetAnomalyIncidentsSchema,
+      inputSchema: GetAnomalyIncidentsShape,
     },
     async (args) => {
       // Handle all parameter scenarios: {}, undefined, or missing entirely
-      const { states, limit, offset } = args || {};
+      const { states, limit, offset } = GetAnomalyIncidentsSchema.parse(args || {});
       const appId = getEffectiveAppId();
       if (!appId) {
         return {

--- a/experimental/appsignal/shared/src/tools/get-apps.ts
+++ b/experimental/appsignal/shared/src/tools/get-apps.ts
@@ -1,14 +1,12 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { IAppsignalClient } from '../appsignal-client/appsignal-client.js';
 
-export function getAppsTool(server: McpServer, clientFactory: () => IAppsignalClient) {
+export function getAppsTool(_server: McpServer, clientFactory: () => IAppsignalClient) {
   const GetAppsShape = {};
 
-  return server.registerTool(
-    'get_apps',
-    {
-      title: 'Get Apps',
-      description: `Retrieve a list of all available AppSignal applications associated with your account. This tool is essential for discovering which applications you can monitor and must be used before selecting a specific app to work with. Returns an array of application objects containing details like app ID, name, environment, and other metadata. This is typically the first tool you'll use when starting an AppSignal monitoring session.
+  return {
+    name: 'get_apps',
+    description: `Retrieve a list of all available AppSignal applications associated with your account. This tool is essential for discovering which applications you can monitor and must be used before selecting a specific app to work with. Returns an array of application objects containing details like app ID, name, environment, and other metadata. This is typically the first tool you'll use when starting an AppSignal monitoring session.
 
 Example response:
 {
@@ -32,9 +30,8 @@ Use cases:
 - Starting a monitoring session by listing available apps
 - Verifying which applications are configured in AppSignal
 - Finding the correct app ID to use with other monitoring tools`,
-      inputSchema: GetAppsShape,
-    },
-    async () => {
+    inputSchema: GetAppsShape,
+    handler: async () => {
       try {
         const client = clientFactory();
         const apps = await client.getApps();
@@ -42,7 +39,7 @@ Use cases:
         return {
           content: [
             {
-              type: 'text',
+              type: 'text' as const,
               text: JSON.stringify(
                 {
                   apps: apps,
@@ -57,12 +54,12 @@ Use cases:
         return {
           content: [
             {
-              type: 'text',
+              type: 'text' as const,
               text: `Error fetching apps: ${error instanceof Error ? error.message : 'Unknown error'}`,
             },
           ],
         };
       }
-    }
-  );
+    },
+  };
 }

--- a/experimental/appsignal/shared/src/tools/get-apps.ts
+++ b/experimental/appsignal/shared/src/tools/get-apps.ts
@@ -1,9 +1,8 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import { z } from 'zod';
 import { IAppsignalClient } from '../appsignal-client/appsignal-client.js';
 
 export function getAppsTool(server: McpServer, clientFactory: () => IAppsignalClient) {
-  const GetAppsSchema = z.object({});
+  const GetAppsShape = {};
 
   return server.registerTool(
     'get_apps',
@@ -33,7 +32,7 @@ Use cases:
 - Starting a monitoring session by listing available apps
 - Verifying which applications are configured in AppSignal
 - Finding the correct app ID to use with other monitoring tools`,
-      inputSchema: GetAppsSchema,
+      inputSchema: GetAppsShape,
     },
     async () => {
       try {

--- a/experimental/appsignal/shared/src/tools/get-apps.ts
+++ b/experimental/appsignal/shared/src/tools/get-apps.ts
@@ -33,14 +33,9 @@ Use cases:
 - Starting a monitoring session by listing available apps
 - Verifying which applications are configured in AppSignal
 - Finding the correct app ID to use with other monitoring tools`,
-      inputSchema: {
-        type: 'object',
-        properties: {},
-        required: [],
-      } as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+      inputSchema: GetAppsSchema,
     },
-    async (args: unknown) => {
-      GetAppsSchema.parse(args || {});
+    async () => {
       try {
         const client = clientFactory();
         const apps = await client.getApps();
@@ -48,7 +43,7 @@ Use cases:
         return {
           content: [
             {
-              type: 'text' as const,
+              type: 'text',
               text: JSON.stringify(
                 {
                   apps: apps,
@@ -63,7 +58,7 @@ Use cases:
         return {
           content: [
             {
-              type: 'text' as const,
+              type: 'text',
               text: `Error fetching apps: ${error instanceof Error ? error.message : 'Unknown error'}`,
             },
           ],

--- a/experimental/appsignal/shared/src/tools/get-apps.ts
+++ b/experimental/appsignal/shared/src/tools/get-apps.ts
@@ -1,10 +1,15 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
 import { IAppsignalClient } from '../appsignal-client/appsignal-client.js';
 
 export function getAppsTool(server: McpServer, clientFactory: () => IAppsignalClient) {
-  return server.tool(
+  const GetAppsSchema = z.object({});
+
+  return server.registerTool(
     'get_apps',
-    `Retrieve a list of all available AppSignal applications associated with your account. This tool is essential for discovering which applications you can monitor and must be used before selecting a specific app to work with. Returns an array of application objects containing details like app ID, name, environment, and other metadata. This is typically the first tool you'll use when starting an AppSignal monitoring session.
+    {
+      title: 'Get Apps',
+      description: `Retrieve a list of all available AppSignal applications associated with your account. This tool is essential for discovering which applications you can monitor and must be used before selecting a specific app to work with. Returns an array of application objects containing details like app ID, name, environment, and other metadata. This is typically the first tool you'll use when starting an AppSignal monitoring session.
 
 Example response:
 {
@@ -28,7 +33,8 @@ Use cases:
 - Starting a monitoring session by listing available apps
 - Verifying which applications are configured in AppSignal
 - Finding the correct app ID to use with other monitoring tools`,
-    {},
+      inputSchema: GetAppsSchema,
+    },
     async () => {
       try {
         const client = clientFactory();

--- a/experimental/appsignal/shared/src/tools/get-apps.ts
+++ b/experimental/appsignal/shared/src/tools/get-apps.ts
@@ -33,9 +33,14 @@ Use cases:
 - Starting a monitoring session by listing available apps
 - Verifying which applications are configured in AppSignal
 - Finding the correct app ID to use with other monitoring tools`,
-      inputSchema: GetAppsSchema,
+      inputSchema: {
+        type: 'object',
+        properties: {},
+        required: [],
+      } as any, // eslint-disable-line @typescript-eslint/no-explicit-any
     },
-    async () => {
+    async (args: unknown) => {
+      GetAppsSchema.parse(args || {});
       try {
         const client = clientFactory();
         const apps = await client.getApps();
@@ -43,7 +48,7 @@ Use cases:
         return {
           content: [
             {
-              type: 'text',
+              type: 'text' as const,
               text: JSON.stringify(
                 {
                   apps: apps,
@@ -58,7 +63,7 @@ Use cases:
         return {
           content: [
             {
-              type: 'text',
+              type: 'text' as const,
               text: `Error fetching apps: ${error instanceof Error ? error.message : 'Unknown error'}`,
             },
           ],

--- a/experimental/appsignal/shared/src/tools/get-exception-incident-sample.ts
+++ b/experimental/appsignal/shared/src/tools/get-exception-incident-sample.ts
@@ -13,10 +13,12 @@ export function getExceptionIncidentSampleTool(
   server: McpServer,
   clientFactory: () => IAppsignalClient
 ) {
-  const GetExceptionIncidentSampleSchema = z.object({
+  const GetExceptionIncidentSampleShape = {
     incidentNumber: z.string().describe(PARAM_DESCRIPTIONS.incidentNumber),
     offset: z.number().int().min(0).default(0).describe(PARAM_DESCRIPTIONS.offset),
-  });
+  };
+
+  const GetExceptionIncidentSampleSchema = z.object(GetExceptionIncidentSampleShape);
 
   return server.registerTool(
     'get_exception_incident_sample',
@@ -59,9 +61,10 @@ Use cases:
 - Understanding the context where errors occurred
 - Investigating user-specific error conditions
 - Tracking error occurrences across different app versions`,
-      inputSchema: GetExceptionIncidentSampleSchema,
+      inputSchema: GetExceptionIncidentSampleShape,
     },
-    async ({ incidentNumber, offset }) => {
+    async (args) => {
+      const { incidentNumber, offset } = GetExceptionIncidentSampleSchema.parse(args);
       const appId = getEffectiveAppId();
       if (!appId) {
         return {

--- a/experimental/appsignal/shared/src/tools/get-exception-incident-sample.ts
+++ b/experimental/appsignal/shared/src/tools/get-exception-incident-sample.ts
@@ -3,13 +3,26 @@ import { z } from 'zod';
 import { getEffectiveAppId } from '../state.js';
 import { IAppsignalClient } from '../appsignal-client/appsignal-client.js';
 
+// Parameter descriptions - single source of truth
+const PARAM_DESCRIPTIONS = {
+  incidentNumber: 'The unique number of the exception incident',
+  offset: 'Sample index to retrieve (0 for most recent, 1 for second most recent, etc.)',
+} as const;
+
 export function getExceptionIncidentSampleTool(
   server: McpServer,
   clientFactory: () => IAppsignalClient
 ) {
-  return server.tool(
+  const GetExceptionIncidentSampleSchema = z.object({
+    incidentNumber: z.string().describe(PARAM_DESCRIPTIONS.incidentNumber),
+    offset: z.number().int().min(0).default(0).describe(PARAM_DESCRIPTIONS.offset),
+  });
+
+  return server.registerTool(
     'get_exception_incident_sample',
-    `Retrieve sample data for a specific occurrence of an exception incident. While exception incidents group similar errors together, this tool provides context of a single occurrence, including request parameters, session data, and environment details. Note: Due to API limitations, the actual exception message and backtrace are not available.
+    {
+      title: 'Get Exception Incident Sample',
+      description: `Retrieve sample data for a specific occurrence of an exception incident. While exception incidents group similar errors together, this tool provides context of a single occurrence, including request parameters, session data, and environment details. Note: Due to API limitations, the actual exception message and backtrace are not available.
 
 💡 Recommended follow-up: After retrieving the sample, use the search_logs tool with:
 - Time range around the sample's timestamp (-10 seconds through +3 seconds)
@@ -46,14 +59,7 @@ Use cases:
 - Understanding the context where errors occurred
 - Investigating user-specific error conditions
 - Tracking error occurrences across different app versions`,
-    {
-      incidentNumber: z.string().describe('The unique number of the exception incident'),
-      offset: z
-        .number()
-        .int()
-        .min(0)
-        .default(0)
-        .describe('Sample index to retrieve (0 for most recent, 1 for second most recent, etc.)'),
+      inputSchema: GetExceptionIncidentSampleSchema,
     },
     async ({ incidentNumber, offset }) => {
       const appId = getEffectiveAppId();

--- a/experimental/appsignal/shared/src/tools/get-exception-incident-sample.ts
+++ b/experimental/appsignal/shared/src/tools/get-exception-incident-sample.ts
@@ -59,15 +59,29 @@ Use cases:
 - Understanding the context where errors occurred
 - Investigating user-specific error conditions
 - Tracking error occurrences across different app versions`,
-      inputSchema: GetExceptionIncidentSampleSchema,
+      inputSchema: {
+        type: 'object',
+        properties: {
+          incidentNumber: {
+            type: 'string',
+            description: PARAM_DESCRIPTIONS.incidentNumber,
+          },
+          offset: {
+            type: 'number',
+            description: PARAM_DESCRIPTIONS.offset,
+          },
+        },
+        required: ['incidentNumber'],
+      } as any, // eslint-disable-line @typescript-eslint/no-explicit-any
     },
-    async ({ incidentNumber, offset }) => {
+    async (args: unknown) => {
+      const { incidentNumber, offset } = GetExceptionIncidentSampleSchema.parse(args);
       const appId = getEffectiveAppId();
       if (!appId) {
         return {
           content: [
             {
-              type: 'text',
+              type: 'text' as const,
               text: 'Error: No app ID configured. Please use select_app_id tool first or set APPSIGNAL_APP_ID environment variable.',
             },
           ],
@@ -81,7 +95,7 @@ Use cases:
         return {
           content: [
             {
-              type: 'text',
+              type: 'text' as const,
               text: JSON.stringify(sample, null, 2),
             },
           ],
@@ -90,7 +104,7 @@ Use cases:
         return {
           content: [
             {
-              type: 'text',
+              type: 'text' as const,
               text: `Error fetching exception incident sample: ${error instanceof Error ? error.message : 'Unknown error'}`,
             },
           ],

--- a/experimental/appsignal/shared/src/tools/get-exception-incident-sample.ts
+++ b/experimental/appsignal/shared/src/tools/get-exception-incident-sample.ts
@@ -10,7 +10,7 @@ const PARAM_DESCRIPTIONS = {
 } as const;
 
 export function getExceptionIncidentSampleTool(
-  server: McpServer,
+  _server: McpServer,
   clientFactory: () => IAppsignalClient
 ) {
   const GetExceptionIncidentSampleShape = {
@@ -20,11 +20,9 @@ export function getExceptionIncidentSampleTool(
 
   const GetExceptionIncidentSampleSchema = z.object(GetExceptionIncidentSampleShape);
 
-  return server.registerTool(
-    'get_exception_incident_sample',
-    {
-      title: 'Get Exception Incident Sample',
-      description: `Retrieve sample data for a specific occurrence of an exception incident. While exception incidents group similar errors together, this tool provides context of a single occurrence, including request parameters, session data, and environment details. Note: Due to API limitations, the actual exception message and backtrace are not available.
+  return {
+    name: 'get_exception_incident_sample',
+    description: `Retrieve sample data for a specific occurrence of an exception incident. While exception incidents group similar errors together, this tool provides context of a single occurrence, including request parameters, session data, and environment details. Note: Due to API limitations, the actual exception message and backtrace are not available.
 
 💡 Recommended follow-up: After retrieving the sample, use the search_logs tool with:
 - Time range around the sample's timestamp (-10 seconds through +3 seconds)
@@ -61,16 +59,15 @@ Use cases:
 - Understanding the context where errors occurred
 - Investigating user-specific error conditions
 - Tracking error occurrences across different app versions`,
-      inputSchema: GetExceptionIncidentSampleShape,
-    },
-    async (args) => {
+    inputSchema: GetExceptionIncidentSampleShape,
+    handler: async (args: unknown) => {
       const { incidentNumber, offset } = GetExceptionIncidentSampleSchema.parse(args);
       const appId = getEffectiveAppId();
       if (!appId) {
         return {
           content: [
             {
-              type: 'text',
+              type: 'text' as const,
               text: 'Error: No app ID configured. Please use select_app_id tool first or set APPSIGNAL_APP_ID environment variable.',
             },
           ],
@@ -84,7 +81,7 @@ Use cases:
         return {
           content: [
             {
-              type: 'text',
+              type: 'text' as const,
               text: JSON.stringify(sample, null, 2),
             },
           ],
@@ -93,12 +90,12 @@ Use cases:
         return {
           content: [
             {
-              type: 'text',
+              type: 'text' as const,
               text: `Error fetching exception incident sample: ${error instanceof Error ? error.message : 'Unknown error'}`,
             },
           ],
         };
       }
-    }
-  );
+    },
+  };
 }

--- a/experimental/appsignal/shared/src/tools/get-exception-incident-sample.ts
+++ b/experimental/appsignal/shared/src/tools/get-exception-incident-sample.ts
@@ -59,29 +59,15 @@ Use cases:
 - Understanding the context where errors occurred
 - Investigating user-specific error conditions
 - Tracking error occurrences across different app versions`,
-      inputSchema: {
-        type: 'object',
-        properties: {
-          incidentNumber: {
-            type: 'string',
-            description: PARAM_DESCRIPTIONS.incidentNumber,
-          },
-          offset: {
-            type: 'number',
-            description: PARAM_DESCRIPTIONS.offset,
-          },
-        },
-        required: ['incidentNumber'],
-      } as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+      inputSchema: GetExceptionIncidentSampleSchema,
     },
-    async (args: unknown) => {
-      const { incidentNumber, offset } = GetExceptionIncidentSampleSchema.parse(args);
+    async ({ incidentNumber, offset }) => {
       const appId = getEffectiveAppId();
       if (!appId) {
         return {
           content: [
             {
-              type: 'text' as const,
+              type: 'text',
               text: 'Error: No app ID configured. Please use select_app_id tool first or set APPSIGNAL_APP_ID environment variable.',
             },
           ],
@@ -95,7 +81,7 @@ Use cases:
         return {
           content: [
             {
-              type: 'text' as const,
+              type: 'text',
               text: JSON.stringify(sample, null, 2),
             },
           ],
@@ -104,7 +90,7 @@ Use cases:
         return {
           content: [
             {
-              type: 'text' as const,
+              type: 'text',
               text: `Error fetching exception incident sample: ${error instanceof Error ? error.message : 'Unknown error'}`,
             },
           ],

--- a/experimental/appsignal/shared/src/tools/get-exception-incident.ts
+++ b/experimental/appsignal/shared/src/tools/get-exception-incident.ts
@@ -50,15 +50,25 @@ Use cases:
 - Analyzing stack traces to identify root causes
 - Tracking which users are affected by specific errors
 - Monitoring the resolution status of known issues`,
-      inputSchema: GetExceptionIncidentSchema,
+      inputSchema: {
+        type: 'object',
+        properties: {
+          incidentNumber: {
+            type: 'string',
+            description: PARAM_DESCRIPTIONS.incidentNumber,
+          },
+        },
+        required: ['incidentNumber'],
+      } as any, // eslint-disable-line @typescript-eslint/no-explicit-any
     },
-    async ({ incidentNumber }) => {
+    async (args: unknown) => {
+      const { incidentNumber } = GetExceptionIncidentSchema.parse(args);
       const appId = getEffectiveAppId();
       if (!appId) {
         return {
           content: [
             {
-              type: 'text',
+              type: 'text' as const,
               text: 'Error: No app ID configured. Please use select_app_id tool first or set APPSIGNAL_APP_ID environment variable.',
             },
           ],
@@ -72,7 +82,7 @@ Use cases:
         return {
           content: [
             {
-              type: 'text',
+              type: 'text' as const,
               text: JSON.stringify(incident, null, 2),
             },
           ],
@@ -81,7 +91,7 @@ Use cases:
         return {
           content: [
             {
-              type: 'text',
+              type: 'text' as const,
               text: `Error fetching exception incident details: ${error instanceof Error ? error.message : 'Unknown error'}`,
             },
           ],

--- a/experimental/appsignal/shared/src/tools/get-exception-incident.ts
+++ b/experimental/appsignal/shared/src/tools/get-exception-incident.ts
@@ -50,25 +50,15 @@ Use cases:
 - Analyzing stack traces to identify root causes
 - Tracking which users are affected by specific errors
 - Monitoring the resolution status of known issues`,
-      inputSchema: {
-        type: 'object',
-        properties: {
-          incidentNumber: {
-            type: 'string',
-            description: PARAM_DESCRIPTIONS.incidentNumber,
-          },
-        },
-        required: ['incidentNumber'],
-      } as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+      inputSchema: GetExceptionIncidentSchema,
     },
-    async (args: unknown) => {
-      const { incidentNumber } = GetExceptionIncidentSchema.parse(args);
+    async ({ incidentNumber }) => {
       const appId = getEffectiveAppId();
       if (!appId) {
         return {
           content: [
             {
-              type: 'text' as const,
+              type: 'text',
               text: 'Error: No app ID configured. Please use select_app_id tool first or set APPSIGNAL_APP_ID environment variable.',
             },
           ],
@@ -82,7 +72,7 @@ Use cases:
         return {
           content: [
             {
-              type: 'text' as const,
+              type: 'text',
               text: JSON.stringify(incident, null, 2),
             },
           ],
@@ -91,7 +81,7 @@ Use cases:
         return {
           content: [
             {
-              type: 'text' as const,
+              type: 'text',
               text: `Error fetching exception incident details: ${error instanceof Error ? error.message : 'Unknown error'}`,
             },
           ],

--- a/experimental/appsignal/shared/src/tools/get-exception-incident.ts
+++ b/experimental/appsignal/shared/src/tools/get-exception-incident.ts
@@ -9,9 +9,11 @@ const PARAM_DESCRIPTIONS = {
 } as const;
 
 export function getExceptionIncidentTool(server: McpServer, clientFactory: () => IAppsignalClient) {
-  const GetExceptionIncidentSchema = z.object({
+  const GetExceptionIncidentShape = {
     incidentNumber: z.string().describe(PARAM_DESCRIPTIONS.incidentNumber),
-  });
+  };
+
+  const GetExceptionIncidentSchema = z.object(GetExceptionIncidentShape);
 
   return server.registerTool(
     'get_exception_incident',
@@ -50,9 +52,10 @@ Use cases:
 - Analyzing stack traces to identify root causes
 - Tracking which users are affected by specific errors
 - Monitoring the resolution status of known issues`,
-      inputSchema: GetExceptionIncidentSchema,
+      inputSchema: GetExceptionIncidentShape,
     },
-    async ({ incidentNumber }) => {
+    async (args) => {
+      const { incidentNumber } = GetExceptionIncidentSchema.parse(args);
       const appId = getEffectiveAppId();
       if (!appId) {
         return {

--- a/experimental/appsignal/shared/src/tools/get-exception-incident.ts
+++ b/experimental/appsignal/shared/src/tools/get-exception-incident.ts
@@ -3,10 +3,21 @@ import { z } from 'zod';
 import { getEffectiveAppId } from '../state.js';
 import { IAppsignalClient } from '../appsignal-client/appsignal-client.js';
 
+// Parameter descriptions - single source of truth
+const PARAM_DESCRIPTIONS = {
+  incidentNumber: 'The unique number of the exception incident to retrieve',
+} as const;
+
 export function getExceptionIncidentTool(server: McpServer, clientFactory: () => IAppsignalClient) {
-  return server.tool(
+  const GetExceptionIncidentSchema = z.object({
+    incidentNumber: z.string().describe(PARAM_DESCRIPTIONS.incidentNumber),
+  });
+
+  return server.registerTool(
     'get_exception_incident',
-    `Retrieve detailed information about a specific exception incident in your AppSignal application. Exception incidents represent errors, crashes, or unhandled exceptions that occurred in your application. This tool provides comprehensive details about a single exception, including the error message, stack trace, occurrence count, affected users, and environment context.
+    {
+      title: 'Get Exception Incident',
+      description: `Retrieve detailed information about a specific exception incident in your AppSignal application. Exception incidents represent errors, crashes, or unhandled exceptions that occurred in your application. This tool provides comprehensive details about a single exception, including the error message, stack trace, occurrence count, affected users, and environment context.
 
 Example response:
 {
@@ -39,10 +50,7 @@ Use cases:
 - Analyzing stack traces to identify root causes
 - Tracking which users are affected by specific errors
 - Monitoring the resolution status of known issues`,
-    {
-      incidentNumber: z
-        .string()
-        .describe('The unique number of the exception incident to retrieve'),
+      inputSchema: GetExceptionIncidentSchema,
     },
     async ({ incidentNumber }) => {
       const appId = getEffectiveAppId();

--- a/experimental/appsignal/shared/src/tools/get-exception-incident.ts
+++ b/experimental/appsignal/shared/src/tools/get-exception-incident.ts
@@ -8,18 +8,19 @@ const PARAM_DESCRIPTIONS = {
   incidentNumber: 'The unique number of the exception incident to retrieve',
 } as const;
 
-export function getExceptionIncidentTool(server: McpServer, clientFactory: () => IAppsignalClient) {
+export function getExceptionIncidentTool(
+  _server: McpServer,
+  clientFactory: () => IAppsignalClient
+) {
   const GetExceptionIncidentShape = {
     incidentNumber: z.string().describe(PARAM_DESCRIPTIONS.incidentNumber),
   };
 
   const GetExceptionIncidentSchema = z.object(GetExceptionIncidentShape);
 
-  return server.registerTool(
-    'get_exception_incident',
-    {
-      title: 'Get Exception Incident',
-      description: `Retrieve detailed information about a specific exception incident in your AppSignal application. Exception incidents represent errors, crashes, or unhandled exceptions that occurred in your application. This tool provides comprehensive details about a single exception, including the error message, stack trace, occurrence count, affected users, and environment context.
+  return {
+    name: 'get_exception_incident',
+    description: `Retrieve detailed information about a specific exception incident in your AppSignal application. Exception incidents represent errors, crashes, or unhandled exceptions that occurred in your application. This tool provides comprehensive details about a single exception, including the error message, stack trace, occurrence count, affected users, and environment context.
 
 Example response:
 {
@@ -52,16 +53,15 @@ Use cases:
 - Analyzing stack traces to identify root causes
 - Tracking which users are affected by specific errors
 - Monitoring the resolution status of known issues`,
-      inputSchema: GetExceptionIncidentShape,
-    },
-    async (args) => {
+    inputSchema: GetExceptionIncidentShape,
+    handler: async (args: unknown) => {
       const { incidentNumber } = GetExceptionIncidentSchema.parse(args);
       const appId = getEffectiveAppId();
       if (!appId) {
         return {
           content: [
             {
-              type: 'text',
+              type: 'text' as const,
               text: 'Error: No app ID configured. Please use select_app_id tool first or set APPSIGNAL_APP_ID environment variable.',
             },
           ],
@@ -75,7 +75,7 @@ Use cases:
         return {
           content: [
             {
-              type: 'text',
+              type: 'text' as const,
               text: JSON.stringify(incident, null, 2),
             },
           ],
@@ -84,12 +84,12 @@ Use cases:
         return {
           content: [
             {
-              type: 'text',
+              type: 'text' as const,
               text: `Error fetching exception incident details: ${error instanceof Error ? error.message : 'Unknown error'}`,
             },
           ],
         };
       }
-    }
-  );
+    },
+  };
 }

--- a/experimental/appsignal/shared/src/tools/get-exception-incidents.ts
+++ b/experimental/appsignal/shared/src/tools/get-exception-incidents.ts
@@ -15,14 +15,16 @@ export function getExceptionIncidentsTool(
   server: McpServer,
   clientFactory: () => IAppsignalClient
 ) {
-  const GetExceptionIncidentsSchema = z.object({
+  const GetExceptionIncidentsShape = {
     states: z
       .array(z.enum(['OPEN', 'CLOSED', 'WIP']))
       .optional()
       .describe(PARAM_DESCRIPTIONS.states),
     limit: z.number().optional().describe(PARAM_DESCRIPTIONS.limit),
     offset: z.number().optional().describe(PARAM_DESCRIPTIONS.offset),
-  });
+  };
+
+  const GetExceptionIncidentsSchema = z.object(GetExceptionIncidentsShape);
 
   return server.registerTool(
     'get_exception_incidents',
@@ -71,11 +73,11 @@ Use cases:
 - Monitoring error trends and patterns
 - Tracking the status of error resolution efforts
 - Identifying the most frequent or critical exceptions`,
-      inputSchema: GetExceptionIncidentsSchema,
+      inputSchema: GetExceptionIncidentsShape,
     },
     async (args) => {
       // Handle all parameter scenarios: {}, undefined, or missing entirely
-      const { states, limit, offset } = args || {};
+      const { states, limit, offset } = GetExceptionIncidentsSchema.parse(args || {});
       const appId = getEffectiveAppId();
       if (!appId) {
         return {

--- a/experimental/appsignal/shared/src/tools/get-exception-incidents.ts
+++ b/experimental/appsignal/shared/src/tools/get-exception-incidents.ts
@@ -71,38 +71,17 @@ Use cases:
 - Monitoring error trends and patterns
 - Tracking the status of error resolution efforts
 - Identifying the most frequent or critical exceptions`,
-      inputSchema: {
-        type: 'object',
-        properties: {
-          states: {
-            type: 'array',
-            items: {
-              type: 'string',
-              enum: ['OPEN', 'CLOSED', 'WIP'],
-            },
-            description: PARAM_DESCRIPTIONS.states,
-          },
-          limit: {
-            type: 'number',
-            description: PARAM_DESCRIPTIONS.limit,
-          },
-          offset: {
-            type: 'number',
-            description: PARAM_DESCRIPTIONS.offset,
-          },
-        },
-        required: [],
-      } as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+      inputSchema: GetExceptionIncidentsSchema,
     },
-    async (args: unknown) => {
+    async (args) => {
       // Handle all parameter scenarios: {}, undefined, or missing entirely
-      const { states, limit, offset } = GetExceptionIncidentsSchema.parse(args || {});
+      const { states, limit, offset } = args || {};
       const appId = getEffectiveAppId();
       if (!appId) {
         return {
           content: [
             {
-              type: 'text' as const,
+              type: 'text',
               text: 'Error: No app ID configured. Please use select_app_id tool first or set APPSIGNAL_APP_ID environment variable.',
             },
           ],
@@ -121,7 +100,7 @@ Use cases:
         return {
           content: [
             {
-              type: 'text' as const,
+              type: 'text',
               text: JSON.stringify(result, null, 2),
             },
           ],
@@ -130,7 +109,7 @@ Use cases:
         return {
           content: [
             {
-              type: 'text' as const,
+              type: 'text',
               text: `Error fetching exception incidents: ${error instanceof Error ? error.message : 'Unknown error'}`,
             },
           ],

--- a/experimental/appsignal/shared/src/tools/get-exception-incidents.ts
+++ b/experimental/appsignal/shared/src/tools/get-exception-incidents.ts
@@ -12,7 +12,7 @@ const PARAM_DESCRIPTIONS = {
 } as const;
 
 export function getExceptionIncidentsTool(
-  server: McpServer,
+  _server: McpServer,
   clientFactory: () => IAppsignalClient
 ) {
   const GetExceptionIncidentsShape = {
@@ -26,11 +26,9 @@ export function getExceptionIncidentsTool(
 
   const GetExceptionIncidentsSchema = z.object(GetExceptionIncidentsShape);
 
-  return server.registerTool(
-    'get_exception_incidents',
-    {
-      title: 'Get Exception Incidents',
-      description: `Retrieve a list of exception incidents from your AppSignal application. Exception incidents group similar errors together, showing patterns of application crashes, errors, and unhandled exceptions. This tool provides an overview of all exception types affecting your application, with filtering and pagination capabilities.
+  return {
+    name: 'get_exception_incidents',
+    description: `Retrieve a list of exception incidents from your AppSignal application. Exception incidents group similar errors together, showing patterns of application crashes, errors, and unhandled exceptions. This tool provides an overview of all exception types affecting your application, with filtering and pagination capabilities.
 
 Example response:
 {
@@ -73,9 +71,8 @@ Use cases:
 - Monitoring error trends and patterns
 - Tracking the status of error resolution efforts
 - Identifying the most frequent or critical exceptions`,
-      inputSchema: GetExceptionIncidentsShape,
-    },
-    async (args) => {
+    inputSchema: GetExceptionIncidentsShape,
+    handler: async (args: unknown) => {
       // Handle all parameter scenarios: {}, undefined, or missing entirely
       const { states, limit, offset } = GetExceptionIncidentsSchema.parse(args || {});
       const appId = getEffectiveAppId();
@@ -83,7 +80,7 @@ Use cases:
         return {
           content: [
             {
-              type: 'text',
+              type: 'text' as const,
               text: 'Error: No app ID configured. Please use select_app_id tool first or set APPSIGNAL_APP_ID environment variable.',
             },
           ],
@@ -102,7 +99,7 @@ Use cases:
         return {
           content: [
             {
-              type: 'text',
+              type: 'text' as const,
               text: JSON.stringify(result, null, 2),
             },
           ],
@@ -111,12 +108,12 @@ Use cases:
         return {
           content: [
             {
-              type: 'text',
+              type: 'text' as const,
               text: `Error fetching exception incidents: ${error instanceof Error ? error.message : 'Unknown error'}`,
             },
           ],
         };
       }
-    }
-  );
+    },
+  };
 }

--- a/experimental/appsignal/shared/src/tools/get-exception-incidents.ts
+++ b/experimental/appsignal/shared/src/tools/get-exception-incidents.ts
@@ -71,17 +71,38 @@ Use cases:
 - Monitoring error trends and patterns
 - Tracking the status of error resolution efforts
 - Identifying the most frequent or critical exceptions`,
-      inputSchema: GetExceptionIncidentsSchema,
+      inputSchema: {
+        type: 'object',
+        properties: {
+          states: {
+            type: 'array',
+            items: {
+              type: 'string',
+              enum: ['OPEN', 'CLOSED', 'WIP'],
+            },
+            description: PARAM_DESCRIPTIONS.states,
+          },
+          limit: {
+            type: 'number',
+            description: PARAM_DESCRIPTIONS.limit,
+          },
+          offset: {
+            type: 'number',
+            description: PARAM_DESCRIPTIONS.offset,
+          },
+        },
+        required: [],
+      } as any, // eslint-disable-line @typescript-eslint/no-explicit-any
     },
-    async (args) => {
+    async (args: unknown) => {
       // Handle all parameter scenarios: {}, undefined, or missing entirely
-      const { states, limit, offset } = args || {};
+      const { states, limit, offset } = GetExceptionIncidentsSchema.parse(args || {});
       const appId = getEffectiveAppId();
       if (!appId) {
         return {
           content: [
             {
-              type: 'text',
+              type: 'text' as const,
               text: 'Error: No app ID configured. Please use select_app_id tool first or set APPSIGNAL_APP_ID environment variable.',
             },
           ],
@@ -100,7 +121,7 @@ Use cases:
         return {
           content: [
             {
-              type: 'text',
+              type: 'text' as const,
               text: JSON.stringify(result, null, 2),
             },
           ],
@@ -109,7 +130,7 @@ Use cases:
         return {
           content: [
             {
-              type: 'text',
+              type: 'text' as const,
               text: `Error fetching exception incidents: ${error instanceof Error ? error.message : 'Unknown error'}`,
             },
           ],

--- a/experimental/appsignal/shared/src/tools/get-log-incident.ts
+++ b/experimental/appsignal/shared/src/tools/get-log-incident.ts
@@ -3,10 +3,21 @@ import { z } from 'zod';
 import { getEffectiveAppId } from '../state.js';
 import { IAppsignalClient } from '../appsignal-client/appsignal-client.js';
 
+// Parameter descriptions - single source of truth
+const PARAM_DESCRIPTIONS = {
+  incidentNumber: 'The unique number of the log incident to retrieve',
+} as const;
+
 export function getLogIncidentTool(server: McpServer, clientFactory: () => IAppsignalClient) {
-  return server.tool(
+  const GetLogIncidentSchema = z.object({
+    incidentNumber: z.string().describe(PARAM_DESCRIPTIONS.incidentNumber),
+  });
+
+  return server.registerTool(
     'get_log_incident',
-    `Retrieve detailed information about a specific log incident in your AppSignal application. Log incidents represent patterns in your application logs that indicate potential issues, such as repeated error messages, warning patterns, or critical system events. This tool provides comprehensive details about a single log incident including the log pattern, frequency, and context.
+    {
+      title: 'Get Log Incident',
+      description: `Retrieve detailed information about a specific log incident in your AppSignal application. Log incidents represent patterns in your application logs that indicate potential issues, such as repeated error messages, warning patterns, or critical system events. This tool provides comprehensive details about a single log incident including the log pattern, frequency, and context.
 
 Example response:
 {
@@ -40,7 +51,8 @@ Use cases:
 - Tracking down intermittent issues captured in logs
 - Analyzing the impact of log incidents on different services
 - Monitoring the resolution status of identified log patterns`,
-    { incidentNumber: z.string().describe('The unique number of the log incident to retrieve') },
+      inputSchema: GetLogIncidentSchema,
+    },
     async ({ incidentNumber }) => {
       const appId = getEffectiveAppId();
       if (!appId) {

--- a/experimental/appsignal/shared/src/tools/get-log-incident.ts
+++ b/experimental/appsignal/shared/src/tools/get-log-incident.ts
@@ -51,15 +51,25 @@ Use cases:
 - Tracking down intermittent issues captured in logs
 - Analyzing the impact of log incidents on different services
 - Monitoring the resolution status of identified log patterns`,
-      inputSchema: GetLogIncidentSchema,
+      inputSchema: {
+        type: 'object',
+        properties: {
+          incidentNumber: {
+            type: 'string',
+            description: PARAM_DESCRIPTIONS.incidentNumber,
+          },
+        },
+        required: ['incidentNumber'],
+      } as any, // eslint-disable-line @typescript-eslint/no-explicit-any
     },
-    async ({ incidentNumber }) => {
+    async (args: unknown) => {
+      const { incidentNumber } = GetLogIncidentSchema.parse(args);
       const appId = getEffectiveAppId();
       if (!appId) {
         return {
           content: [
             {
-              type: 'text',
+              type: 'text' as const,
               text: 'Error: No app ID configured. Please use select_app_id tool first or set APPSIGNAL_APP_ID environment variable.',
             },
           ],
@@ -73,7 +83,7 @@ Use cases:
         return {
           content: [
             {
-              type: 'text',
+              type: 'text' as const,
               text: JSON.stringify(incident, null, 2),
             },
           ],
@@ -82,7 +92,7 @@ Use cases:
         return {
           content: [
             {
-              type: 'text',
+              type: 'text' as const,
               text: `Error fetching log incident details: ${error instanceof Error ? error.message : 'Unknown error'}`,
             },
           ],

--- a/experimental/appsignal/shared/src/tools/get-log-incident.ts
+++ b/experimental/appsignal/shared/src/tools/get-log-incident.ts
@@ -8,18 +8,16 @@ const PARAM_DESCRIPTIONS = {
   incidentNumber: 'The unique number of the log incident to retrieve',
 } as const;
 
-export function getLogIncidentTool(server: McpServer, clientFactory: () => IAppsignalClient) {
+export function getLogIncidentTool(_server: McpServer, clientFactory: () => IAppsignalClient) {
   const GetLogIncidentShape = {
     incidentNumber: z.string().describe(PARAM_DESCRIPTIONS.incidentNumber),
   };
 
   const GetLogIncidentSchema = z.object(GetLogIncidentShape);
 
-  return server.registerTool(
-    'get_log_incident',
-    {
-      title: 'Get Log Incident',
-      description: `Retrieve detailed information about a specific log incident in your AppSignal application. Log incidents represent patterns in your application logs that indicate potential issues, such as repeated error messages, warning patterns, or critical system events. This tool provides comprehensive details about a single log incident including the log pattern, frequency, and context.
+  return {
+    name: 'get_log_incident',
+    description: `Retrieve detailed information about a specific log incident in your AppSignal application. Log incidents represent patterns in your application logs that indicate potential issues, such as repeated error messages, warning patterns, or critical system events. This tool provides comprehensive details about a single log incident including the log pattern, frequency, and context.
 
 Example response:
 {
@@ -53,16 +51,15 @@ Use cases:
 - Tracking down intermittent issues captured in logs
 - Analyzing the impact of log incidents on different services
 - Monitoring the resolution status of identified log patterns`,
-      inputSchema: GetLogIncidentShape,
-    },
-    async (args) => {
+    inputSchema: GetLogIncidentShape,
+    handler: async (args: unknown) => {
       const { incidentNumber } = GetLogIncidentSchema.parse(args);
       const appId = getEffectiveAppId();
       if (!appId) {
         return {
           content: [
             {
-              type: 'text',
+              type: 'text' as const,
               text: 'Error: No app ID configured. Please use select_app_id tool first or set APPSIGNAL_APP_ID environment variable.',
             },
           ],
@@ -76,7 +73,7 @@ Use cases:
         return {
           content: [
             {
-              type: 'text',
+              type: 'text' as const,
               text: JSON.stringify(incident, null, 2),
             },
           ],
@@ -85,12 +82,12 @@ Use cases:
         return {
           content: [
             {
-              type: 'text',
+              type: 'text' as const,
               text: `Error fetching log incident details: ${error instanceof Error ? error.message : 'Unknown error'}`,
             },
           ],
         };
       }
-    }
-  );
+    },
+  };
 }

--- a/experimental/appsignal/shared/src/tools/get-log-incident.ts
+++ b/experimental/appsignal/shared/src/tools/get-log-incident.ts
@@ -51,25 +51,15 @@ Use cases:
 - Tracking down intermittent issues captured in logs
 - Analyzing the impact of log incidents on different services
 - Monitoring the resolution status of identified log patterns`,
-      inputSchema: {
-        type: 'object',
-        properties: {
-          incidentNumber: {
-            type: 'string',
-            description: PARAM_DESCRIPTIONS.incidentNumber,
-          },
-        },
-        required: ['incidentNumber'],
-      } as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+      inputSchema: GetLogIncidentSchema,
     },
-    async (args: unknown) => {
-      const { incidentNumber } = GetLogIncidentSchema.parse(args);
+    async ({ incidentNumber }) => {
       const appId = getEffectiveAppId();
       if (!appId) {
         return {
           content: [
             {
-              type: 'text' as const,
+              type: 'text',
               text: 'Error: No app ID configured. Please use select_app_id tool first or set APPSIGNAL_APP_ID environment variable.',
             },
           ],
@@ -83,7 +73,7 @@ Use cases:
         return {
           content: [
             {
-              type: 'text' as const,
+              type: 'text',
               text: JSON.stringify(incident, null, 2),
             },
           ],
@@ -92,7 +82,7 @@ Use cases:
         return {
           content: [
             {
-              type: 'text' as const,
+              type: 'text',
               text: `Error fetching log incident details: ${error instanceof Error ? error.message : 'Unknown error'}`,
             },
           ],

--- a/experimental/appsignal/shared/src/tools/get-log-incident.ts
+++ b/experimental/appsignal/shared/src/tools/get-log-incident.ts
@@ -9,9 +9,11 @@ const PARAM_DESCRIPTIONS = {
 } as const;
 
 export function getLogIncidentTool(server: McpServer, clientFactory: () => IAppsignalClient) {
-  const GetLogIncidentSchema = z.object({
+  const GetLogIncidentShape = {
     incidentNumber: z.string().describe(PARAM_DESCRIPTIONS.incidentNumber),
-  });
+  };
+
+  const GetLogIncidentSchema = z.object(GetLogIncidentShape);
 
   return server.registerTool(
     'get_log_incident',
@@ -51,9 +53,10 @@ Use cases:
 - Tracking down intermittent issues captured in logs
 - Analyzing the impact of log incidents on different services
 - Monitoring the resolution status of identified log patterns`,
-      inputSchema: GetLogIncidentSchema,
+      inputSchema: GetLogIncidentShape,
     },
-    async ({ incidentNumber }) => {
+    async (args) => {
+      const { incidentNumber } = GetLogIncidentSchema.parse(args);
       const appId = getEffectiveAppId();
       if (!appId) {
         return {

--- a/experimental/appsignal/shared/src/tools/get-log-incidents.ts
+++ b/experimental/appsignal/shared/src/tools/get-log-incidents.ts
@@ -68,38 +68,17 @@ Use cases:
 - Prioritizing which log patterns to investigate
 - Tracking the status of log-based issues
 - Monitoring for new or escalating log patterns`,
-      inputSchema: {
-        type: 'object',
-        properties: {
-          states: {
-            type: 'array',
-            items: {
-              type: 'string',
-              enum: ['OPEN', 'CLOSED', 'WIP'],
-            },
-            description: PARAM_DESCRIPTIONS.states,
-          },
-          limit: {
-            type: 'number',
-            description: PARAM_DESCRIPTIONS.limit,
-          },
-          offset: {
-            type: 'number',
-            description: PARAM_DESCRIPTIONS.offset,
-          },
-        },
-        required: [],
-      } as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+      inputSchema: GetLogIncidentsSchema,
     },
-    async (args: unknown) => {
+    async (args) => {
       // Handle all parameter scenarios: {}, undefined, or missing entirely
-      const { states, limit, offset } = GetLogIncidentsSchema.parse(args || {});
+      const { states, limit, offset } = args || {};
       const appId = getEffectiveAppId();
       if (!appId) {
         return {
           content: [
             {
-              type: 'text' as const,
+              type: 'text',
               text: 'Error: No app ID configured. Please use select_app_id tool first or set APPSIGNAL_APP_ID environment variable.',
             },
           ],
@@ -118,7 +97,7 @@ Use cases:
         return {
           content: [
             {
-              type: 'text' as const,
+              type: 'text',
               text: JSON.stringify(result, null, 2),
             },
           ],
@@ -127,7 +106,7 @@ Use cases:
         return {
           content: [
             {
-              type: 'text' as const,
+              type: 'text',
               text: `Error fetching log incidents: ${error instanceof Error ? error.message : 'Unknown error'}`,
             },
           ],

--- a/experimental/appsignal/shared/src/tools/get-log-incidents.ts
+++ b/experimental/appsignal/shared/src/tools/get-log-incidents.ts
@@ -11,7 +11,7 @@ const PARAM_DESCRIPTIONS = {
   offset: 'Number of incidents to skip for pagination. Defaults to 0',
 } as const;
 
-export function getLogIncidentsTool(server: McpServer, clientFactory: () => IAppsignalClient) {
+export function getLogIncidentsTool(_server: McpServer, clientFactory: () => IAppsignalClient) {
   const GetLogIncidentsShape = {
     states: z
       .array(z.enum(['OPEN', 'CLOSED', 'WIP']))
@@ -23,11 +23,9 @@ export function getLogIncidentsTool(server: McpServer, clientFactory: () => IApp
 
   const GetLogIncidentsSchema = z.object(GetLogIncidentsShape);
 
-  return server.registerTool(
-    'get_log_incidents',
-    {
-      title: 'Get Log Incidents',
-      description: `Retrieve a list of log incidents from your AppSignal application. Log incidents are automatically detected patterns in your application logs that may indicate issues, such as repeated errors, warnings, or critical events. This tool provides an overview of all log patterns requiring attention, with filtering and pagination support.
+  return {
+    name: 'get_log_incidents',
+    description: `Retrieve a list of log incidents from your AppSignal application. Log incidents are automatically detected patterns in your application logs that may indicate issues, such as repeated errors, warnings, or critical events. This tool provides an overview of all log patterns requiring attention, with filtering and pagination support.
 
 Example response:
 {
@@ -70,9 +68,8 @@ Use cases:
 - Prioritizing which log patterns to investigate
 - Tracking the status of log-based issues
 - Monitoring for new or escalating log patterns`,
-      inputSchema: GetLogIncidentsShape,
-    },
-    async (args) => {
+    inputSchema: GetLogIncidentsShape,
+    handler: async (args: unknown) => {
       // Handle all parameter scenarios: {}, undefined, or missing entirely
       const { states, limit, offset } = GetLogIncidentsSchema.parse(args || {});
       const appId = getEffectiveAppId();
@@ -80,7 +77,7 @@ Use cases:
         return {
           content: [
             {
-              type: 'text',
+              type: 'text' as const,
               text: 'Error: No app ID configured. Please use select_app_id tool first or set APPSIGNAL_APP_ID environment variable.',
             },
           ],
@@ -99,7 +96,7 @@ Use cases:
         return {
           content: [
             {
-              type: 'text',
+              type: 'text' as const,
               text: JSON.stringify(result, null, 2),
             },
           ],
@@ -108,12 +105,12 @@ Use cases:
         return {
           content: [
             {
-              type: 'text',
+              type: 'text' as const,
               text: `Error fetching log incidents: ${error instanceof Error ? error.message : 'Unknown error'}`,
             },
           ],
         };
       }
-    }
-  );
+    },
+  };
 }

--- a/experimental/appsignal/shared/src/tools/get-log-incidents.ts
+++ b/experimental/appsignal/shared/src/tools/get-log-incidents.ts
@@ -12,14 +12,16 @@ const PARAM_DESCRIPTIONS = {
 } as const;
 
 export function getLogIncidentsTool(server: McpServer, clientFactory: () => IAppsignalClient) {
-  const GetLogIncidentsSchema = z.object({
+  const GetLogIncidentsShape = {
     states: z
       .array(z.enum(['OPEN', 'CLOSED', 'WIP']))
       .optional()
       .describe(PARAM_DESCRIPTIONS.states),
     limit: z.number().optional().describe(PARAM_DESCRIPTIONS.limit),
     offset: z.number().optional().describe(PARAM_DESCRIPTIONS.offset),
-  });
+  };
+
+  const GetLogIncidentsSchema = z.object(GetLogIncidentsShape);
 
   return server.registerTool(
     'get_log_incidents',
@@ -68,11 +70,11 @@ Use cases:
 - Prioritizing which log patterns to investigate
 - Tracking the status of log-based issues
 - Monitoring for new or escalating log patterns`,
-      inputSchema: GetLogIncidentsSchema,
+      inputSchema: GetLogIncidentsShape,
     },
     async (args) => {
       // Handle all parameter scenarios: {}, undefined, or missing entirely
-      const { states, limit, offset } = args || {};
+      const { states, limit, offset } = GetLogIncidentsSchema.parse(args || {});
       const appId = getEffectiveAppId();
       if (!appId) {
         return {

--- a/experimental/appsignal/shared/src/tools/get-log-incidents.ts
+++ b/experimental/appsignal/shared/src/tools/get-log-incidents.ts
@@ -68,17 +68,38 @@ Use cases:
 - Prioritizing which log patterns to investigate
 - Tracking the status of log-based issues
 - Monitoring for new or escalating log patterns`,
-      inputSchema: GetLogIncidentsSchema,
+      inputSchema: {
+        type: 'object',
+        properties: {
+          states: {
+            type: 'array',
+            items: {
+              type: 'string',
+              enum: ['OPEN', 'CLOSED', 'WIP'],
+            },
+            description: PARAM_DESCRIPTIONS.states,
+          },
+          limit: {
+            type: 'number',
+            description: PARAM_DESCRIPTIONS.limit,
+          },
+          offset: {
+            type: 'number',
+            description: PARAM_DESCRIPTIONS.offset,
+          },
+        },
+        required: [],
+      } as any, // eslint-disable-line @typescript-eslint/no-explicit-any
     },
-    async (args) => {
+    async (args: unknown) => {
       // Handle all parameter scenarios: {}, undefined, or missing entirely
-      const { states, limit, offset } = args || {};
+      const { states, limit, offset } = GetLogIncidentsSchema.parse(args || {});
       const appId = getEffectiveAppId();
       if (!appId) {
         return {
           content: [
             {
-              type: 'text',
+              type: 'text' as const,
               text: 'Error: No app ID configured. Please use select_app_id tool first or set APPSIGNAL_APP_ID environment variable.',
             },
           ],
@@ -97,7 +118,7 @@ Use cases:
         return {
           content: [
             {
-              type: 'text',
+              type: 'text' as const,
               text: JSON.stringify(result, null, 2),
             },
           ],
@@ -106,7 +127,7 @@ Use cases:
         return {
           content: [
             {
-              type: 'text',
+              type: 'text' as const,
               text: `Error fetching log incidents: ${error instanceof Error ? error.message : 'Unknown error'}`,
             },
           ],

--- a/experimental/appsignal/shared/src/tools/get-performance-incident-sample-timeline.ts
+++ b/experimental/appsignal/shared/src/tools/get-performance-incident-sample-timeline.ts
@@ -104,25 +104,15 @@ Use cases:
 - Understanding the call hierarchy and timing breakdown
 - Finding unexpected database queries or external API calls
 - Analyzing memory allocation patterns`,
-      inputSchema: {
-        type: 'object',
-        properties: {
-          incidentNumber: {
-            type: 'string',
-            description: PARAM_DESCRIPTIONS.incidentNumber,
-          },
-        },
-        required: ['incidentNumber'],
-      } as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+      inputSchema: GetPerformanceIncidentSampleTimelineSchema,
     },
-    async (args: unknown) => {
-      const { incidentNumber } = GetPerformanceIncidentSampleTimelineSchema.parse(args);
+    async ({ incidentNumber }) => {
       const appId = getEffectiveAppId();
       if (!appId) {
         return {
           content: [
             {
-              type: 'text' as const,
+              type: 'text',
               text: 'Error: No app ID configured. Please use select_app_id tool first or set APPSIGNAL_APP_ID environment variable.',
             },
           ],
@@ -136,7 +126,7 @@ Use cases:
         return {
           content: [
             {
-              type: 'text' as const,
+              type: 'text',
               text: JSON.stringify(timeline, null, 2),
             },
           ],
@@ -145,7 +135,7 @@ Use cases:
         return {
           content: [
             {
-              type: 'text' as const,
+              type: 'text',
               text: `Error fetching performance incident sample timeline: ${error instanceof Error ? error.message : 'Unknown error'}`,
             },
           ],

--- a/experimental/appsignal/shared/src/tools/get-performance-incident-sample-timeline.ts
+++ b/experimental/appsignal/shared/src/tools/get-performance-incident-sample-timeline.ts
@@ -3,13 +3,24 @@ import { z } from 'zod';
 import { getEffectiveAppId } from '../state.js';
 import { IAppsignalClient } from '../appsignal-client/appsignal-client.js';
 
+// Parameter descriptions - single source of truth
+const PARAM_DESCRIPTIONS = {
+  incidentNumber: 'The number of the performance incident to get the sample timeline for',
+} as const;
+
 export function getPerformanceIncidentSampleTimelineTool(
   server: McpServer,
   clientFactory: () => IAppsignalClient
 ) {
-  return server.tool(
+  const GetPerformanceIncidentSampleTimelineSchema = z.object({
+    incidentNumber: z.string().describe(PARAM_DESCRIPTIONS.incidentNumber),
+  });
+
+  return server.registerTool(
     'get_performance_incident_sample_timeline',
-    `Retrieve the detailed timeline for a performance incident sample from AppSignal. The timeline shows a hierarchical breakdown of all operations performed during a request, including database queries, view rendering, external API calls, and custom instrumentation. This is essential for identifying the exact bottlenecks in slow requests.
+    {
+      title: 'Get Performance Incident Sample Timeline',
+      description: `Retrieve the detailed timeline for a performance incident sample from AppSignal. The timeline shows a hierarchical breakdown of all operations performed during a request, including database queries, view rendering, external API calls, and custom instrumentation. This is essential for identifying the exact bottlenecks in slow requests.
 
 Example response:
 {
@@ -93,10 +104,7 @@ Use cases:
 - Understanding the call hierarchy and timing breakdown
 - Finding unexpected database queries or external API calls
 - Analyzing memory allocation patterns`,
-    {
-      incidentNumber: z
-        .string()
-        .describe('The number of the performance incident to get the sample timeline for'),
+      inputSchema: GetPerformanceIncidentSampleTimelineSchema,
     },
     async ({ incidentNumber }) => {
       const appId = getEffectiveAppId();

--- a/experimental/appsignal/shared/src/tools/get-performance-incident-sample-timeline.ts
+++ b/experimental/appsignal/shared/src/tools/get-performance-incident-sample-timeline.ts
@@ -9,7 +9,7 @@ const PARAM_DESCRIPTIONS = {
 } as const;
 
 export function getPerformanceIncidentSampleTimelineTool(
-  server: McpServer,
+  _server: McpServer,
   clientFactory: () => IAppsignalClient
 ) {
   const GetPerformanceIncidentSampleTimelineShape = {
@@ -20,11 +20,9 @@ export function getPerformanceIncidentSampleTimelineTool(
     GetPerformanceIncidentSampleTimelineShape
   );
 
-  return server.registerTool(
-    'get_performance_incident_sample_timeline',
-    {
-      title: 'Get Performance Incident Sample Timeline',
-      description: `Retrieve the detailed timeline for a performance incident sample from AppSignal. The timeline shows a hierarchical breakdown of all operations performed during a request, including database queries, view rendering, external API calls, and custom instrumentation. This is essential for identifying the exact bottlenecks in slow requests.
+  return {
+    name: 'get_performance_incident_sample_timeline',
+    description: `Retrieve the detailed timeline for a performance incident sample from AppSignal. The timeline shows a hierarchical breakdown of all operations performed during a request, including database queries, view rendering, external API calls, and custom instrumentation. This is essential for identifying the exact bottlenecks in slow requests.
 
 Example response:
 {
@@ -108,16 +106,15 @@ Use cases:
 - Understanding the call hierarchy and timing breakdown
 - Finding unexpected database queries or external API calls
 - Analyzing memory allocation patterns`,
-      inputSchema: GetPerformanceIncidentSampleTimelineShape,
-    },
-    async (args) => {
+    inputSchema: GetPerformanceIncidentSampleTimelineShape,
+    handler: async (args: unknown) => {
       const { incidentNumber } = GetPerformanceIncidentSampleTimelineSchema.parse(args);
       const appId = getEffectiveAppId();
       if (!appId) {
         return {
           content: [
             {
-              type: 'text',
+              type: 'text' as const,
               text: 'Error: No app ID configured. Please use select_app_id tool first or set APPSIGNAL_APP_ID environment variable.',
             },
           ],
@@ -131,7 +128,7 @@ Use cases:
         return {
           content: [
             {
-              type: 'text',
+              type: 'text' as const,
               text: JSON.stringify(timeline, null, 2),
             },
           ],
@@ -140,12 +137,12 @@ Use cases:
         return {
           content: [
             {
-              type: 'text',
+              type: 'text' as const,
               text: `Error fetching performance incident sample timeline: ${error instanceof Error ? error.message : 'Unknown error'}`,
             },
           ],
         };
       }
-    }
-  );
+    },
+  };
 }

--- a/experimental/appsignal/shared/src/tools/get-performance-incident-sample-timeline.ts
+++ b/experimental/appsignal/shared/src/tools/get-performance-incident-sample-timeline.ts
@@ -12,9 +12,13 @@ export function getPerformanceIncidentSampleTimelineTool(
   server: McpServer,
   clientFactory: () => IAppsignalClient
 ) {
-  const GetPerformanceIncidentSampleTimelineSchema = z.object({
+  const GetPerformanceIncidentSampleTimelineShape = {
     incidentNumber: z.string().describe(PARAM_DESCRIPTIONS.incidentNumber),
-  });
+  };
+
+  const GetPerformanceIncidentSampleTimelineSchema = z.object(
+    GetPerformanceIncidentSampleTimelineShape
+  );
 
   return server.registerTool(
     'get_performance_incident_sample_timeline',
@@ -104,9 +108,10 @@ Use cases:
 - Understanding the call hierarchy and timing breakdown
 - Finding unexpected database queries or external API calls
 - Analyzing memory allocation patterns`,
-      inputSchema: GetPerformanceIncidentSampleTimelineSchema,
+      inputSchema: GetPerformanceIncidentSampleTimelineShape,
     },
-    async ({ incidentNumber }) => {
+    async (args) => {
+      const { incidentNumber } = GetPerformanceIncidentSampleTimelineSchema.parse(args);
       const appId = getEffectiveAppId();
       if (!appId) {
         return {

--- a/experimental/appsignal/shared/src/tools/get-performance-incident-sample-timeline.ts
+++ b/experimental/appsignal/shared/src/tools/get-performance-incident-sample-timeline.ts
@@ -104,15 +104,25 @@ Use cases:
 - Understanding the call hierarchy and timing breakdown
 - Finding unexpected database queries or external API calls
 - Analyzing memory allocation patterns`,
-      inputSchema: GetPerformanceIncidentSampleTimelineSchema,
+      inputSchema: {
+        type: 'object',
+        properties: {
+          incidentNumber: {
+            type: 'string',
+            description: PARAM_DESCRIPTIONS.incidentNumber,
+          },
+        },
+        required: ['incidentNumber'],
+      } as any, // eslint-disable-line @typescript-eslint/no-explicit-any
     },
-    async ({ incidentNumber }) => {
+    async (args: unknown) => {
+      const { incidentNumber } = GetPerformanceIncidentSampleTimelineSchema.parse(args);
       const appId = getEffectiveAppId();
       if (!appId) {
         return {
           content: [
             {
-              type: 'text',
+              type: 'text' as const,
               text: 'Error: No app ID configured. Please use select_app_id tool first or set APPSIGNAL_APP_ID environment variable.',
             },
           ],
@@ -126,7 +136,7 @@ Use cases:
         return {
           content: [
             {
-              type: 'text',
+              type: 'text' as const,
               text: JSON.stringify(timeline, null, 2),
             },
           ],
@@ -135,7 +145,7 @@ Use cases:
         return {
           content: [
             {
-              type: 'text',
+              type: 'text' as const,
               text: `Error fetching performance incident sample timeline: ${error instanceof Error ? error.message : 'Unknown error'}`,
             },
           ],

--- a/experimental/appsignal/shared/src/tools/get-performance-incident-sample.ts
+++ b/experimental/appsignal/shared/src/tools/get-performance-incident-sample.ts
@@ -71,25 +71,15 @@ Use cases:
 - Viewing request parameters and custom data for context
 - Checking if N+1 queries occurred in this specific sample
 - Understanding queue wait times vs actual processing time`,
-      inputSchema: {
-        type: 'object',
-        properties: {
-          incidentNumber: {
-            type: 'string',
-            description: PARAM_DESCRIPTIONS.incidentNumber,
-          },
-        },
-        required: ['incidentNumber'],
-      } as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+      inputSchema: GetPerformanceIncidentSampleSchema,
     },
-    async (args: unknown) => {
-      const { incidentNumber } = GetPerformanceIncidentSampleSchema.parse(args);
+    async ({ incidentNumber }) => {
       const appId = getEffectiveAppId();
       if (!appId) {
         return {
           content: [
             {
-              type: 'text' as const,
+              type: 'text',
               text: 'Error: No app ID configured. Please use select_app_id tool first or set APPSIGNAL_APP_ID environment variable.',
             },
           ],
@@ -103,7 +93,7 @@ Use cases:
         return {
           content: [
             {
-              type: 'text' as const,
+              type: 'text',
               text: JSON.stringify(sample, null, 2),
             },
           ],
@@ -112,7 +102,7 @@ Use cases:
         return {
           content: [
             {
-              type: 'text' as const,
+              type: 'text',
               text: `Error fetching performance incident sample: ${error instanceof Error ? error.message : 'Unknown error'}`,
             },
           ],

--- a/experimental/appsignal/shared/src/tools/get-performance-incident-sample.ts
+++ b/experimental/appsignal/shared/src/tools/get-performance-incident-sample.ts
@@ -3,13 +3,24 @@ import { z } from 'zod';
 import { getEffectiveAppId } from '../state.js';
 import { IAppsignalClient } from '../appsignal-client/appsignal-client.js';
 
+// Parameter descriptions - single source of truth
+const PARAM_DESCRIPTIONS = {
+  incidentNumber: 'The number of the performance incident to get a sample for',
+} as const;
+
 export function getPerformanceIncidentSampleTool(
   server: McpServer,
   clientFactory: () => IAppsignalClient
 ) {
-  return server.tool(
+  const GetPerformanceIncidentSampleSchema = z.object({
+    incidentNumber: z.string().describe(PARAM_DESCRIPTIONS.incidentNumber),
+  });
+
+  return server.registerTool(
     'get_performance_incident_sample',
-    `Retrieve a sample transaction for a specific performance incident from AppSignal. Samples provide detailed timing information about a specific slow request or operation, helping you understand exactly where time is being spent.
+    {
+      title: 'Get Performance Incident Sample',
+      description: `Retrieve a sample transaction for a specific performance incident from AppSignal. Samples provide detailed timing information about a specific slow request or operation, helping you understand exactly where time is being spent.
 
 💡 Recommended follow-up: After retrieving the sample, use the search_logs tool with:
 - Time range around the sample's timestamp (-10 seconds through +3 seconds)
@@ -60,10 +71,7 @@ Use cases:
 - Viewing request parameters and custom data for context
 - Checking if N+1 queries occurred in this specific sample
 - Understanding queue wait times vs actual processing time`,
-    {
-      incidentNumber: z
-        .string()
-        .describe('The number of the performance incident to get a sample for'),
+      inputSchema: GetPerformanceIncidentSampleSchema,
     },
     async ({ incidentNumber }) => {
       const appId = getEffectiveAppId();

--- a/experimental/appsignal/shared/src/tools/get-performance-incident-sample.ts
+++ b/experimental/appsignal/shared/src/tools/get-performance-incident-sample.ts
@@ -71,15 +71,25 @@ Use cases:
 - Viewing request parameters and custom data for context
 - Checking if N+1 queries occurred in this specific sample
 - Understanding queue wait times vs actual processing time`,
-      inputSchema: GetPerformanceIncidentSampleSchema,
+      inputSchema: {
+        type: 'object',
+        properties: {
+          incidentNumber: {
+            type: 'string',
+            description: PARAM_DESCRIPTIONS.incidentNumber,
+          },
+        },
+        required: ['incidentNumber'],
+      } as any, // eslint-disable-line @typescript-eslint/no-explicit-any
     },
-    async ({ incidentNumber }) => {
+    async (args: unknown) => {
+      const { incidentNumber } = GetPerformanceIncidentSampleSchema.parse(args);
       const appId = getEffectiveAppId();
       if (!appId) {
         return {
           content: [
             {
-              type: 'text',
+              type: 'text' as const,
               text: 'Error: No app ID configured. Please use select_app_id tool first or set APPSIGNAL_APP_ID environment variable.',
             },
           ],
@@ -93,7 +103,7 @@ Use cases:
         return {
           content: [
             {
-              type: 'text',
+              type: 'text' as const,
               text: JSON.stringify(sample, null, 2),
             },
           ],
@@ -102,7 +112,7 @@ Use cases:
         return {
           content: [
             {
-              type: 'text',
+              type: 'text' as const,
               text: `Error fetching performance incident sample: ${error instanceof Error ? error.message : 'Unknown error'}`,
             },
           ],

--- a/experimental/appsignal/shared/src/tools/get-performance-incident-sample.ts
+++ b/experimental/appsignal/shared/src/tools/get-performance-incident-sample.ts
@@ -9,7 +9,7 @@ const PARAM_DESCRIPTIONS = {
 } as const;
 
 export function getPerformanceIncidentSampleTool(
-  server: McpServer,
+  _server: McpServer,
   clientFactory: () => IAppsignalClient
 ) {
   const GetPerformanceIncidentSampleShape = {
@@ -18,11 +18,9 @@ export function getPerformanceIncidentSampleTool(
 
   const GetPerformanceIncidentSampleSchema = z.object(GetPerformanceIncidentSampleShape);
 
-  return server.registerTool(
-    'get_performance_incident_sample',
-    {
-      title: 'Get Performance Incident Sample',
-      description: `Retrieve a sample transaction for a specific performance incident from AppSignal. Samples provide detailed timing information about a specific slow request or operation, helping you understand exactly where time is being spent.
+  return {
+    name: 'get_performance_incident_sample',
+    description: `Retrieve a sample transaction for a specific performance incident from AppSignal. Samples provide detailed timing information about a specific slow request or operation, helping you understand exactly where time is being spent.
 
 💡 Recommended follow-up: After retrieving the sample, use the search_logs tool with:
 - Time range around the sample's timestamp (-10 seconds through +3 seconds)
@@ -73,16 +71,15 @@ Use cases:
 - Viewing request parameters and custom data for context
 - Checking if N+1 queries occurred in this specific sample
 - Understanding queue wait times vs actual processing time`,
-      inputSchema: GetPerformanceIncidentSampleShape,
-    },
-    async (args) => {
+    inputSchema: GetPerformanceIncidentSampleShape,
+    handler: async (args: unknown) => {
       const { incidentNumber } = GetPerformanceIncidentSampleSchema.parse(args);
       const appId = getEffectiveAppId();
       if (!appId) {
         return {
           content: [
             {
-              type: 'text',
+              type: 'text' as const,
               text: 'Error: No app ID configured. Please use select_app_id tool first or set APPSIGNAL_APP_ID environment variable.',
             },
           ],
@@ -96,7 +93,7 @@ Use cases:
         return {
           content: [
             {
-              type: 'text',
+              type: 'text' as const,
               text: JSON.stringify(sample, null, 2),
             },
           ],
@@ -105,12 +102,12 @@ Use cases:
         return {
           content: [
             {
-              type: 'text',
+              type: 'text' as const,
               text: `Error fetching performance incident sample: ${error instanceof Error ? error.message : 'Unknown error'}`,
             },
           ],
         };
       }
-    }
-  );
+    },
+  };
 }

--- a/experimental/appsignal/shared/src/tools/get-performance-incident-sample.ts
+++ b/experimental/appsignal/shared/src/tools/get-performance-incident-sample.ts
@@ -12,9 +12,11 @@ export function getPerformanceIncidentSampleTool(
   server: McpServer,
   clientFactory: () => IAppsignalClient
 ) {
-  const GetPerformanceIncidentSampleSchema = z.object({
+  const GetPerformanceIncidentSampleShape = {
     incidentNumber: z.string().describe(PARAM_DESCRIPTIONS.incidentNumber),
-  });
+  };
+
+  const GetPerformanceIncidentSampleSchema = z.object(GetPerformanceIncidentSampleShape);
 
   return server.registerTool(
     'get_performance_incident_sample',
@@ -71,9 +73,10 @@ Use cases:
 - Viewing request parameters and custom data for context
 - Checking if N+1 queries occurred in this specific sample
 - Understanding queue wait times vs actual processing time`,
-      inputSchema: GetPerformanceIncidentSampleSchema,
+      inputSchema: GetPerformanceIncidentSampleShape,
     },
-    async ({ incidentNumber }) => {
+    async (args) => {
+      const { incidentNumber } = GetPerformanceIncidentSampleSchema.parse(args);
       const appId = getEffectiveAppId();
       if (!appId) {
         return {

--- a/experimental/appsignal/shared/src/tools/get-performance-incident.ts
+++ b/experimental/appsignal/shared/src/tools/get-performance-incident.ts
@@ -3,13 +3,24 @@ import { z } from 'zod';
 import { getEffectiveAppId } from '../state.js';
 import { IAppsignalClient } from '../appsignal-client/appsignal-client.js';
 
+// Parameter descriptions - single source of truth
+const PARAM_DESCRIPTIONS = {
+  incidentNumber: 'The number of the performance incident to retrieve',
+} as const;
+
 export function getPerformanceIncidentTool(
   server: McpServer,
   clientFactory: () => IAppsignalClient
 ) {
-  return server.tool(
+  const GetPerformanceIncidentSchema = z.object({
+    incidentNumber: z.string().describe(PARAM_DESCRIPTIONS.incidentNumber),
+  });
+
+  return server.registerTool(
     'get_performance_incident',
-    `Retrieve details about a specific performance incident from AppSignal. Performance incidents represent specific performance bottlenecks like slow endpoints, database queries, or external API calls. This tool provides detailed information about a single performance issue.
+    {
+      title: 'Get Performance Incident',
+      description: `Retrieve details about a specific performance incident from AppSignal. Performance incidents represent specific performance bottlenecks like slow endpoints, database queries, or external API calls. This tool provides detailed information about a single performance issue.
 
 Example response:
 {
@@ -47,8 +58,7 @@ Use cases:
 - Understanding the impact and frequency of a performance bottleneck
 - Checking if an incident has N+1 query problems
 - Determining if samples are available for deeper analysis`,
-    {
-      incidentNumber: z.string().describe('The number of the performance incident to retrieve'),
+      inputSchema: GetPerformanceIncidentSchema,
     },
     async ({ incidentNumber }) => {
       const appId = getEffectiveAppId();

--- a/experimental/appsignal/shared/src/tools/get-performance-incident.ts
+++ b/experimental/appsignal/shared/src/tools/get-performance-incident.ts
@@ -12,9 +12,11 @@ export function getPerformanceIncidentTool(
   server: McpServer,
   clientFactory: () => IAppsignalClient
 ) {
-  const GetPerformanceIncidentSchema = z.object({
+  const GetPerformanceIncidentShape = {
     incidentNumber: z.string().describe(PARAM_DESCRIPTIONS.incidentNumber),
-  });
+  };
+
+  const GetPerformanceIncidentSchema = z.object(GetPerformanceIncidentShape);
 
   return server.registerTool(
     'get_performance_incident',
@@ -58,9 +60,10 @@ Use cases:
 - Understanding the impact and frequency of a performance bottleneck
 - Checking if an incident has N+1 query problems
 - Determining if samples are available for deeper analysis`,
-      inputSchema: GetPerformanceIncidentSchema,
+      inputSchema: GetPerformanceIncidentShape,
     },
-    async ({ incidentNumber }) => {
+    async (args) => {
+      const { incidentNumber } = GetPerformanceIncidentSchema.parse(args);
       const appId = getEffectiveAppId();
       if (!appId) {
         return {

--- a/experimental/appsignal/shared/src/tools/get-performance-incident.ts
+++ b/experimental/appsignal/shared/src/tools/get-performance-incident.ts
@@ -58,15 +58,25 @@ Use cases:
 - Understanding the impact and frequency of a performance bottleneck
 - Checking if an incident has N+1 query problems
 - Determining if samples are available for deeper analysis`,
-      inputSchema: GetPerformanceIncidentSchema,
+      inputSchema: {
+        type: 'object',
+        properties: {
+          incidentNumber: {
+            type: 'string',
+            description: PARAM_DESCRIPTIONS.incidentNumber,
+          },
+        },
+        required: ['incidentNumber'],
+      } as any, // eslint-disable-line @typescript-eslint/no-explicit-any
     },
-    async ({ incidentNumber }) => {
+    async (args: unknown) => {
+      const { incidentNumber } = GetPerformanceIncidentSchema.parse(args);
       const appId = getEffectiveAppId();
       if (!appId) {
         return {
           content: [
             {
-              type: 'text',
+              type: 'text' as const,
               text: 'Error: No app ID configured. Please use select_app_id tool first or set APPSIGNAL_APP_ID environment variable.',
             },
           ],
@@ -80,7 +90,7 @@ Use cases:
         return {
           content: [
             {
-              type: 'text',
+              type: 'text' as const,
               text: JSON.stringify(incident, null, 2),
             },
           ],
@@ -89,7 +99,7 @@ Use cases:
         return {
           content: [
             {
-              type: 'text',
+              type: 'text' as const,
               text: `Error fetching performance incident: ${error instanceof Error ? error.message : 'Unknown error'}`,
             },
           ],

--- a/experimental/appsignal/shared/src/tools/get-performance-incident.ts
+++ b/experimental/appsignal/shared/src/tools/get-performance-incident.ts
@@ -9,7 +9,7 @@ const PARAM_DESCRIPTIONS = {
 } as const;
 
 export function getPerformanceIncidentTool(
-  server: McpServer,
+  _server: McpServer,
   clientFactory: () => IAppsignalClient
 ) {
   const GetPerformanceIncidentShape = {
@@ -18,11 +18,9 @@ export function getPerformanceIncidentTool(
 
   const GetPerformanceIncidentSchema = z.object(GetPerformanceIncidentShape);
 
-  return server.registerTool(
-    'get_performance_incident',
-    {
-      title: 'Get Performance Incident',
-      description: `Retrieve details about a specific performance incident from AppSignal. Performance incidents represent specific performance bottlenecks like slow endpoints, database queries, or external API calls. This tool provides detailed information about a single performance issue.
+  return {
+    name: 'get_performance_incident',
+    description: `Retrieve details about a specific performance incident from AppSignal. Performance incidents represent specific performance bottlenecks like slow endpoints, database queries, or external API calls. This tool provides detailed information about a single performance issue.
 
 Example response:
 {
@@ -60,16 +58,15 @@ Use cases:
 - Understanding the impact and frequency of a performance bottleneck
 - Checking if an incident has N+1 query problems
 - Determining if samples are available for deeper analysis`,
-      inputSchema: GetPerformanceIncidentShape,
-    },
-    async (args) => {
+    inputSchema: GetPerformanceIncidentShape,
+    handler: async (args: unknown) => {
       const { incidentNumber } = GetPerformanceIncidentSchema.parse(args);
       const appId = getEffectiveAppId();
       if (!appId) {
         return {
           content: [
             {
-              type: 'text',
+              type: 'text' as const,
               text: 'Error: No app ID configured. Please use select_app_id tool first or set APPSIGNAL_APP_ID environment variable.',
             },
           ],
@@ -83,7 +80,7 @@ Use cases:
         return {
           content: [
             {
-              type: 'text',
+              type: 'text' as const,
               text: JSON.stringify(incident, null, 2),
             },
           ],
@@ -92,12 +89,12 @@ Use cases:
         return {
           content: [
             {
-              type: 'text',
+              type: 'text' as const,
               text: `Error fetching performance incident: ${error instanceof Error ? error.message : 'Unknown error'}`,
             },
           ],
         };
       }
-    }
-  );
+    },
+  };
 }

--- a/experimental/appsignal/shared/src/tools/get-performance-incident.ts
+++ b/experimental/appsignal/shared/src/tools/get-performance-incident.ts
@@ -58,25 +58,15 @@ Use cases:
 - Understanding the impact and frequency of a performance bottleneck
 - Checking if an incident has N+1 query problems
 - Determining if samples are available for deeper analysis`,
-      inputSchema: {
-        type: 'object',
-        properties: {
-          incidentNumber: {
-            type: 'string',
-            description: PARAM_DESCRIPTIONS.incidentNumber,
-          },
-        },
-        required: ['incidentNumber'],
-      } as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+      inputSchema: GetPerformanceIncidentSchema,
     },
-    async (args: unknown) => {
-      const { incidentNumber } = GetPerformanceIncidentSchema.parse(args);
+    async ({ incidentNumber }) => {
       const appId = getEffectiveAppId();
       if (!appId) {
         return {
           content: [
             {
-              type: 'text' as const,
+              type: 'text',
               text: 'Error: No app ID configured. Please use select_app_id tool first or set APPSIGNAL_APP_ID environment variable.',
             },
           ],
@@ -90,7 +80,7 @@ Use cases:
         return {
           content: [
             {
-              type: 'text' as const,
+              type: 'text',
               text: JSON.stringify(incident, null, 2),
             },
           ],
@@ -99,7 +89,7 @@ Use cases:
         return {
           content: [
             {
-              type: 'text' as const,
+              type: 'text',
               text: `Error fetching performance incident: ${error instanceof Error ? error.message : 'Unknown error'}`,
             },
           ],

--- a/experimental/appsignal/shared/src/tools/get-performance-incidents.ts
+++ b/experimental/appsignal/shared/src/tools/get-performance-incidents.ts
@@ -89,38 +89,17 @@ Use cases:
 - Monitoring performance trends and patterns
 - Tracking the status of performance optimization efforts
 - Identifying N+1 queries and slow database operations`,
-      inputSchema: {
-        type: 'object',
-        properties: {
-          states: {
-            type: 'array',
-            items: {
-              type: 'string',
-              enum: ['OPEN', 'CLOSED', 'WIP'],
-            },
-            description: PARAM_DESCRIPTIONS.states,
-          },
-          limit: {
-            type: 'number',
-            description: PARAM_DESCRIPTIONS.limit,
-          },
-          offset: {
-            type: 'number',
-            description: PARAM_DESCRIPTIONS.offset,
-          },
-        },
-        required: [],
-      } as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+      inputSchema: GetPerformanceIncidentsSchema,
     },
-    async (args: unknown) => {
+    async (args) => {
       // Handle all parameter scenarios: {}, undefined, or missing entirely
-      const { states, limit, offset } = GetPerformanceIncidentsSchema.parse(args || {});
+      const { states, limit, offset } = args || {};
       const appId = getEffectiveAppId();
       if (!appId) {
         return {
           content: [
             {
-              type: 'text' as const,
+              type: 'text',
               text: 'Error: No app ID configured. Please use select_app_id tool first or set APPSIGNAL_APP_ID environment variable.',
             },
           ],
@@ -143,7 +122,7 @@ Use cases:
         return {
           content: [
             {
-              type: 'text' as const,
+              type: 'text',
               text: JSON.stringify(result, null, 2),
             },
           ],
@@ -152,7 +131,7 @@ Use cases:
         return {
           content: [
             {
-              type: 'text' as const,
+              type: 'text',
               text: `Error fetching performance incidents: ${error instanceof Error ? error.message : 'Unknown error'}`,
             },
           ],

--- a/experimental/appsignal/shared/src/tools/get-performance-incidents.ts
+++ b/experimental/appsignal/shared/src/tools/get-performance-incidents.ts
@@ -89,17 +89,38 @@ Use cases:
 - Monitoring performance trends and patterns
 - Tracking the status of performance optimization efforts
 - Identifying N+1 queries and slow database operations`,
-      inputSchema: GetPerformanceIncidentsSchema,
+      inputSchema: {
+        type: 'object',
+        properties: {
+          states: {
+            type: 'array',
+            items: {
+              type: 'string',
+              enum: ['OPEN', 'CLOSED', 'WIP'],
+            },
+            description: PARAM_DESCRIPTIONS.states,
+          },
+          limit: {
+            type: 'number',
+            description: PARAM_DESCRIPTIONS.limit,
+          },
+          offset: {
+            type: 'number',
+            description: PARAM_DESCRIPTIONS.offset,
+          },
+        },
+        required: [],
+      } as any, // eslint-disable-line @typescript-eslint/no-explicit-any
     },
-    async (args) => {
+    async (args: unknown) => {
       // Handle all parameter scenarios: {}, undefined, or missing entirely
-      const { states, limit, offset } = args || {};
+      const { states, limit, offset } = GetPerformanceIncidentsSchema.parse(args || {});
       const appId = getEffectiveAppId();
       if (!appId) {
         return {
           content: [
             {
-              type: 'text',
+              type: 'text' as const,
               text: 'Error: No app ID configured. Please use select_app_id tool first or set APPSIGNAL_APP_ID environment variable.',
             },
           ],
@@ -122,7 +143,7 @@ Use cases:
         return {
           content: [
             {
-              type: 'text',
+              type: 'text' as const,
               text: JSON.stringify(result, null, 2),
             },
           ],
@@ -131,7 +152,7 @@ Use cases:
         return {
           content: [
             {
-              type: 'text',
+              type: 'text' as const,
               text: `Error fetching performance incidents: ${error instanceof Error ? error.message : 'Unknown error'}`,
             },
           ],

--- a/experimental/appsignal/shared/src/tools/get-performance-incidents.ts
+++ b/experimental/appsignal/shared/src/tools/get-performance-incidents.ts
@@ -12,7 +12,7 @@ const PARAM_DESCRIPTIONS = {
 } as const;
 
 export function getPerformanceIncidentsTool(
-  server: McpServer,
+  _server: McpServer,
   clientFactory: () => IAppsignalClient
 ) {
   const GetPerformanceIncidentsShape = {
@@ -26,11 +26,9 @@ export function getPerformanceIncidentsTool(
 
   const GetPerformanceIncidentsSchema = z.object(GetPerformanceIncidentsShape);
 
-  return server.registerTool(
-    'get_performance_incidents',
-    {
-      title: 'Get Performance Incidents',
-      description: `Retrieve a list of performance incidents from your AppSignal application. Performance incidents identify slow endpoints, database queries, and other performance bottlenecks in your application. This tool provides an overview of all performance issues affecting your application, with filtering and pagination capabilities.
+  return {
+    name: 'get_performance_incidents',
+    description: `Retrieve a list of performance incidents from your AppSignal application. Performance incidents identify slow endpoints, database queries, and other performance bottlenecks in your application. This tool provides an overview of all performance issues affecting your application, with filtering and pagination capabilities.
 
 Example response:
 {
@@ -91,9 +89,8 @@ Use cases:
 - Monitoring performance trends and patterns
 - Tracking the status of performance optimization efforts
 - Identifying N+1 queries and slow database operations`,
-      inputSchema: GetPerformanceIncidentsShape,
-    },
-    async (args) => {
+    inputSchema: GetPerformanceIncidentsShape,
+    handler: async (args: unknown) => {
       // Handle all parameter scenarios: {}, undefined, or missing entirely
       const { states, limit, offset } = GetPerformanceIncidentsSchema.parse(args || {});
       const appId = getEffectiveAppId();
@@ -101,7 +98,7 @@ Use cases:
         return {
           content: [
             {
-              type: 'text',
+              type: 'text' as const,
               text: 'Error: No app ID configured. Please use select_app_id tool first or set APPSIGNAL_APP_ID environment variable.',
             },
           ],
@@ -124,7 +121,7 @@ Use cases:
         return {
           content: [
             {
-              type: 'text',
+              type: 'text' as const,
               text: JSON.stringify(result, null, 2),
             },
           ],
@@ -133,12 +130,12 @@ Use cases:
         return {
           content: [
             {
-              type: 'text',
+              type: 'text' as const,
               text: `Error fetching performance incidents: ${error instanceof Error ? error.message : 'Unknown error'}`,
             },
           ],
         };
       }
-    }
-  );
+    },
+  };
 }

--- a/experimental/appsignal/shared/src/tools/get-performance-incidents.ts
+++ b/experimental/appsignal/shared/src/tools/get-performance-incidents.ts
@@ -15,14 +15,16 @@ export function getPerformanceIncidentsTool(
   server: McpServer,
   clientFactory: () => IAppsignalClient
 ) {
-  const GetPerformanceIncidentsSchema = z.object({
+  const GetPerformanceIncidentsShape = {
     states: z
       .array(z.enum(['OPEN', 'CLOSED', 'WIP']))
       .optional()
       .describe(PARAM_DESCRIPTIONS.states),
     limit: z.number().optional().describe(PARAM_DESCRIPTIONS.limit),
     offset: z.number().optional().describe(PARAM_DESCRIPTIONS.offset),
-  });
+  };
+
+  const GetPerformanceIncidentsSchema = z.object(GetPerformanceIncidentsShape);
 
   return server.registerTool(
     'get_performance_incidents',
@@ -89,11 +91,11 @@ Use cases:
 - Monitoring performance trends and patterns
 - Tracking the status of performance optimization efforts
 - Identifying N+1 queries and slow database operations`,
-      inputSchema: GetPerformanceIncidentsSchema,
+      inputSchema: GetPerformanceIncidentsShape,
     },
     async (args) => {
       // Handle all parameter scenarios: {}, undefined, or missing entirely
-      const { states, limit, offset } = args || {};
+      const { states, limit, offset } = GetPerformanceIncidentsSchema.parse(args || {});
       const appId = getEffectiveAppId();
       if (!appId) {
         return {

--- a/experimental/appsignal/shared/src/tools/search-logs.ts
+++ b/experimental/appsignal/shared/src/tools/search-logs.ts
@@ -80,45 +80,15 @@ Use cases:
 - Analyzing log patterns around specific time periods
 - Debugging by following trace IDs across services
 - Filtering logs by severity to focus on critical issues`,
-      inputSchema: {
-        type: 'object',
-        properties: {
-          query: {
-            type: 'string',
-            description: PARAM_DESCRIPTIONS.query,
-          },
-          limit: {
-            type: 'number',
-            description: PARAM_DESCRIPTIONS.limit,
-          },
-          severities: {
-            type: 'array',
-            items: {
-              type: 'string',
-              enum: ['debug', 'info', 'warn', 'error', 'fatal'],
-            },
-            description: PARAM_DESCRIPTIONS.severities,
-          },
-          start: {
-            type: 'string',
-            description: PARAM_DESCRIPTIONS.start,
-          },
-          end: {
-            type: 'string',
-            description: PARAM_DESCRIPTIONS.end,
-          },
-        },
-        required: ['query'],
-      } as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+      inputSchema: SearchLogsSchema,
     },
-    async (args: unknown) => {
-      const { query, limit, severities, start, end } = SearchLogsSchema.parse(args);
+    async ({ query, limit, severities, start, end }) => {
       const appId = getEffectiveAppId();
       if (!appId) {
         return {
           content: [
             {
-              type: 'text' as const,
+              type: 'text',
               text: 'Error: No app ID configured. Please use select_app_id tool first or set APPSIGNAL_APP_ID environment variable.',
             },
           ],
@@ -132,7 +102,7 @@ Use cases:
         return {
           content: [
             {
-              type: 'text' as const,
+              type: 'text',
               text: JSON.stringify(logs, null, 2),
             },
           ],
@@ -141,7 +111,7 @@ Use cases:
         return {
           content: [
             {
-              type: 'text' as const,
+              type: 'text',
               text: `Error searching logs: ${error instanceof Error ? error.message : 'Unknown error'}`,
             },
           ],

--- a/experimental/appsignal/shared/src/tools/search-logs.ts
+++ b/experimental/appsignal/shared/src/tools/search-logs.ts
@@ -14,7 +14,7 @@ const PARAM_DESCRIPTIONS = {
 } as const;
 
 export function searchLogsTool(server: McpServer, clientFactory: () => IAppsignalClient) {
-  const SearchLogsSchema = z.object({
+  const SearchLogsShape = {
     query: z.string().describe(PARAM_DESCRIPTIONS.query),
     limit: z.number().int().positive().default(50).describe(PARAM_DESCRIPTIONS.limit),
     severities: z
@@ -23,7 +23,9 @@ export function searchLogsTool(server: McpServer, clientFactory: () => IAppsigna
       .describe(PARAM_DESCRIPTIONS.severities),
     start: z.string().optional().describe(PARAM_DESCRIPTIONS.start),
     end: z.string().optional().describe(PARAM_DESCRIPTIONS.end),
-  });
+  };
+
+  const SearchLogsSchema = z.object(SearchLogsShape);
 
   return server.registerTool(
     'search_logs',
@@ -80,9 +82,10 @@ Use cases:
 - Analyzing log patterns around specific time periods
 - Debugging by following trace IDs across services
 - Filtering logs by severity to focus on critical issues`,
-      inputSchema: SearchLogsSchema,
+      inputSchema: SearchLogsShape,
     },
-    async ({ query, limit, severities, start, end }) => {
+    async (args) => {
+      const { query, limit, severities, start, end } = SearchLogsSchema.parse(args);
       const appId = getEffectiveAppId();
       if (!appId) {
         return {

--- a/experimental/appsignal/shared/src/tools/search-logs.ts
+++ b/experimental/appsignal/shared/src/tools/search-logs.ts
@@ -13,7 +13,7 @@ const PARAM_DESCRIPTIONS = {
   end: 'End time for the search window in ISO 8601 format (e.g., "2024-01-15T23:59:59Z")',
 } as const;
 
-export function searchLogsTool(server: McpServer, clientFactory: () => IAppsignalClient) {
+export function searchLogsTool(_server: McpServer, clientFactory: () => IAppsignalClient) {
   const SearchLogsShape = {
     query: z.string().describe(PARAM_DESCRIPTIONS.query),
     limit: z.number().int().positive().default(50).describe(PARAM_DESCRIPTIONS.limit),
@@ -27,11 +27,9 @@ export function searchLogsTool(server: McpServer, clientFactory: () => IAppsigna
 
   const SearchLogsSchema = z.object(SearchLogsShape);
 
-  return server.registerTool(
-    'search_logs',
-    {
-      title: 'Search Logs',
-      description: `Search through application logs in AppSignal with powerful filtering capabilities. This tool allows you to query logs by content, filter by severity levels, and retrieve recent log entries matching your criteria. It's essential for troubleshooting specific issues, analyzing application behavior, and investigating error conditions.
+  return {
+    name: 'search_logs',
+    description: `Search through application logs in AppSignal with powerful filtering capabilities. This tool allows you to query logs by content, filter by severity levels, and retrieve recent log entries matching your criteria. It's essential for troubleshooting specific issues, analyzing application behavior, and investigating error conditions.
 
 Note that it can be very helpful to use start/end parameters around the time of an incident to pull together all the context on it. Generally, you probably want 10 seconds leading up to the incident through 3 seconds after it; and then expand from there if that's not enough context.
 
@@ -82,16 +80,15 @@ Use cases:
 - Analyzing log patterns around specific time periods
 - Debugging by following trace IDs across services
 - Filtering logs by severity to focus on critical issues`,
-      inputSchema: SearchLogsShape,
-    },
-    async (args) => {
+    inputSchema: SearchLogsShape,
+    handler: async (args: unknown) => {
       const { query, limit, severities, start, end } = SearchLogsSchema.parse(args);
       const appId = getEffectiveAppId();
       if (!appId) {
         return {
           content: [
             {
-              type: 'text',
+              type: 'text' as const,
               text: 'Error: No app ID configured. Please use select_app_id tool first or set APPSIGNAL_APP_ID environment variable.',
             },
           ],
@@ -105,7 +102,7 @@ Use cases:
         return {
           content: [
             {
-              type: 'text',
+              type: 'text' as const,
               text: JSON.stringify(logs, null, 2),
             },
           ],
@@ -114,12 +111,12 @@ Use cases:
         return {
           content: [
             {
-              type: 'text',
+              type: 'text' as const,
               text: `Error searching logs: ${error instanceof Error ? error.message : 'Unknown error'}`,
             },
           ],
         };
       }
-    }
-  );
+    },
+  };
 }

--- a/experimental/appsignal/shared/src/tools/search-logs.ts
+++ b/experimental/appsignal/shared/src/tools/search-logs.ts
@@ -80,15 +80,45 @@ Use cases:
 - Analyzing log patterns around specific time periods
 - Debugging by following trace IDs across services
 - Filtering logs by severity to focus on critical issues`,
-      inputSchema: SearchLogsSchema,
+      inputSchema: {
+        type: 'object',
+        properties: {
+          query: {
+            type: 'string',
+            description: PARAM_DESCRIPTIONS.query,
+          },
+          limit: {
+            type: 'number',
+            description: PARAM_DESCRIPTIONS.limit,
+          },
+          severities: {
+            type: 'array',
+            items: {
+              type: 'string',
+              enum: ['debug', 'info', 'warn', 'error', 'fatal'],
+            },
+            description: PARAM_DESCRIPTIONS.severities,
+          },
+          start: {
+            type: 'string',
+            description: PARAM_DESCRIPTIONS.start,
+          },
+          end: {
+            type: 'string',
+            description: PARAM_DESCRIPTIONS.end,
+          },
+        },
+        required: ['query'],
+      } as any, // eslint-disable-line @typescript-eslint/no-explicit-any
     },
-    async ({ query, limit, severities, start, end }) => {
+    async (args: unknown) => {
+      const { query, limit, severities, start, end } = SearchLogsSchema.parse(args);
       const appId = getEffectiveAppId();
       if (!appId) {
         return {
           content: [
             {
-              type: 'text',
+              type: 'text' as const,
               text: 'Error: No app ID configured. Please use select_app_id tool first or set APPSIGNAL_APP_ID environment variable.',
             },
           ],
@@ -102,7 +132,7 @@ Use cases:
         return {
           content: [
             {
-              type: 'text',
+              type: 'text' as const,
               text: JSON.stringify(logs, null, 2),
             },
           ],
@@ -111,7 +141,7 @@ Use cases:
         return {
           content: [
             {
-              type: 'text',
+              type: 'text' as const,
               text: `Error searching logs: ${error instanceof Error ? error.message : 'Unknown error'}`,
             },
           ],

--- a/experimental/appsignal/shared/src/tools/select-app-id.ts
+++ b/experimental/appsignal/shared/src/tools/select-app-id.ts
@@ -14,9 +14,11 @@ export function selectAppIdTool(
   enableMainTools?: () => void,
   _clientFactory?: () => IAppsignalClient
 ) {
-  const SelectAppIdSchema = z.object({
+  const SelectAppIdShape = {
     appId: z.string().describe(PARAM_DESCRIPTIONS.appId),
-  });
+  };
+
+  const SelectAppIdSchema = z.object(SelectAppIdShape);
 
   return server.registerTool(
     toolName,
@@ -33,9 +35,10 @@ This tool is crucial for:
 - Activating incident monitoring tools for a specific app
 - Switching between different applications during a session
 - Establishing the context for all subsequent monitoring operations`,
-      inputSchema: SelectAppIdSchema,
+      inputSchema: SelectAppIdShape,
     },
-    async ({ appId }) => {
+    async (args) => {
+      const { appId } = SelectAppIdSchema.parse(args);
       // Store the selected app ID
       setSelectedAppId(appId);
 

--- a/experimental/appsignal/shared/src/tools/select-app-id.ts
+++ b/experimental/appsignal/shared/src/tools/select-app-id.ts
@@ -33,9 +33,19 @@ This tool is crucial for:
 - Activating incident monitoring tools for a specific app
 - Switching between different applications during a session
 - Establishing the context for all subsequent monitoring operations`,
-      inputSchema: SelectAppIdSchema,
+      inputSchema: {
+        type: 'object',
+        properties: {
+          appId: {
+            type: 'string',
+            description: PARAM_DESCRIPTIONS.appId,
+          },
+        },
+        required: ['appId'],
+      } as any, // eslint-disable-line @typescript-eslint/no-explicit-any
     },
-    async ({ appId }) => {
+    async (args: unknown) => {
+      const { appId } = SelectAppIdSchema.parse(args);
       // Store the selected app ID
       setSelectedAppId(appId);
 
@@ -48,7 +58,7 @@ This tool is crucial for:
       return {
         content: [
           {
-            type: 'text',
+            type: 'text' as const,
             text: `Successfully ${action} app ID: ${appId}. All AppSignal tools are now available.`,
           },
         ],

--- a/experimental/appsignal/shared/src/tools/select-app-id.ts
+++ b/experimental/appsignal/shared/src/tools/select-app-id.ts
@@ -33,19 +33,9 @@ This tool is crucial for:
 - Activating incident monitoring tools for a specific app
 - Switching between different applications during a session
 - Establishing the context for all subsequent monitoring operations`,
-      inputSchema: {
-        type: 'object',
-        properties: {
-          appId: {
-            type: 'string',
-            description: PARAM_DESCRIPTIONS.appId,
-          },
-        },
-        required: ['appId'],
-      } as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+      inputSchema: SelectAppIdSchema,
     },
-    async (args: unknown) => {
-      const { appId } = SelectAppIdSchema.parse(args);
+    async ({ appId }) => {
       // Store the selected app ID
       setSelectedAppId(appId);
 
@@ -58,7 +48,7 @@ This tool is crucial for:
       return {
         content: [
           {
-            type: 'text' as const,
+            type: 'text',
             text: `Successfully ${action} app ID: ${appId}. All AppSignal tools are now available.`,
           },
         ],

--- a/experimental/appsignal/shared/src/tools/select-app-id.ts
+++ b/experimental/appsignal/shared/src/tools/select-app-id.ts
@@ -9,7 +9,7 @@ const PARAM_DESCRIPTIONS = {
 } as const;
 
 export function selectAppIdTool(
-  server: McpServer,
+  _server: McpServer,
   toolName: string,
   enableMainTools?: () => void,
   _clientFactory?: () => IAppsignalClient
@@ -20,11 +20,9 @@ export function selectAppIdTool(
 
   const SelectAppIdSchema = z.object(SelectAppIdShape);
 
-  return server.registerTool(
-    toolName,
-    {
-      title: toolName === 'change_app_id' ? 'Change App ID' : 'Select App ID',
-      description: `Select a specific AppSignal application to monitor and enable all incident management tools. This tool must be called after get_apps to activate the monitoring capabilities for a particular application. Once an app is selected, all other AppSignal tools (exception incidents, log incidents, anomaly detection, etc.) become available for use. The selection persists for the entire session unless changed.
+  return {
+    name: toolName,
+    description: `Select a specific AppSignal application to monitor and enable all incident management tools. This tool must be called after get_apps to activate the monitoring capabilities for a particular application. Once an app is selected, all other AppSignal tools (exception incidents, log incidents, anomaly detection, etc.) become available for use. The selection persists for the entire session unless changed.
 
 Example usage:
 - First use get_apps to list available applications
@@ -35,9 +33,8 @@ This tool is crucial for:
 - Activating incident monitoring tools for a specific app
 - Switching between different applications during a session
 - Establishing the context for all subsequent monitoring operations`,
-      inputSchema: SelectAppIdShape,
-    },
-    async (args) => {
+    inputSchema: SelectAppIdShape,
+    handler: async (args: unknown) => {
       const { appId } = SelectAppIdSchema.parse(args);
       // Store the selected app ID
       setSelectedAppId(appId);
@@ -51,11 +48,11 @@ This tool is crucial for:
       return {
         content: [
           {
-            type: 'text',
+            type: 'text' as const,
             text: `Successfully ${action} app ID: ${appId}. All AppSignal tools are now available.`,
           },
         ],
       };
-    }
-  );
+    },
+  };
 }

--- a/experimental/twist/CHANGELOG.md
+++ b/experimental/twist/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Applied DRY (Don't Repeat Yourself) pattern to tool parameter descriptions across all tools
+  - Extracted parameter descriptions into `PARAM_DESCRIPTIONS` constants to maintain single source of truth
+  - Both Zod schemas and inputSchema now reference the same descriptions
+  - Improves maintainability and prevents description drift between schema definitions
+  - Applied to: `create-thread.ts`, `add-message-to-thread.ts`, `close-thread.ts`, `get-channel.ts`, `get-thread.ts`
+
 ## [0.1.15] - 2025-07-03
 
 ### Added

--- a/experimental/twist/shared/src/tools/add-message-to-thread.ts
+++ b/experimental/twist/shared/src/tools/add-message-to-thread.ts
@@ -2,21 +2,21 @@ import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { z } from 'zod';
 import type { ClientFactory } from '../server.js';
 
+// Parameter descriptions (single source of truth)
+const PARAM_DESCRIPTIONS = {
+  thread_id:
+    'The unique identifier of the thread (e.g., "789012"). Use get_threads to find thread IDs',
+  content:
+    'The message text to post. Supports line breaks for formatting. Keep messages focused and relevant to the thread topic',
+} as const;
+
 /**
  * Tool for adding a message to an existing thread
  */
 export function addMessageToThreadTool(server: Server, clientFactory: ClientFactory) {
   const AddMessageSchema = z.object({
-    thread_id: z
-      .string()
-      .describe(
-        'The unique identifier of the thread (e.g., "789012"). Use get_threads to find thread IDs'
-      ),
-    content: z
-      .string()
-      .describe(
-        'The message text to post. Supports line breaks for formatting. Keep messages focused and relevant to the thread topic'
-      ),
+    thread_id: z.string().describe(PARAM_DESCRIPTIONS.thread_id),
+    content: z.string().describe(PARAM_DESCRIPTIONS.content),
   });
 
   return {
@@ -43,13 +43,11 @@ Use cases:
       properties: {
         thread_id: {
           type: 'string',
-          description:
-            'The unique identifier of the thread (e.g., "789012"). Use get_threads to find thread IDs',
+          description: PARAM_DESCRIPTIONS.thread_id,
         },
         content: {
           type: 'string',
-          description:
-            'The message text to post. Supports line breaks for formatting. Keep messages focused and relevant to the thread topic',
+          description: PARAM_DESCRIPTIONS.content,
         },
       },
       required: ['thread_id', 'content'],

--- a/experimental/twist/shared/src/tools/close-thread.ts
+++ b/experimental/twist/shared/src/tools/close-thread.ts
@@ -2,18 +2,20 @@ import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { z } from 'zod';
 import type { ClientFactory } from '../server.js';
 
+// Parameter descriptions (single source of truth)
+const PARAM_DESCRIPTIONS = {
+  thread_id: 'The unique identifier of the thread to close (e.g., "789012")',
+  message:
+    'Optional closing message to add to the thread. If not provided, defaults to "Thread closed"',
+} as const;
+
 /**
  * Tool for closing a thread
  */
 export function closeThreadTool(server: Server, clientFactory: ClientFactory) {
   const CloseThreadSchema = z.object({
-    thread_id: z.string().describe('The unique identifier of the thread to close (e.g., "789012")'),
-    message: z
-      .string()
-      .optional()
-      .describe(
-        'Optional closing message to add to the thread. If not provided, defaults to "Thread closed"'
-      ),
+    thread_id: z.string().describe(PARAM_DESCRIPTIONS.thread_id),
+    message: z.string().optional().describe(PARAM_DESCRIPTIONS.message),
   });
 
   return {
@@ -40,12 +42,11 @@ Use cases:
       properties: {
         thread_id: {
           type: 'string',
-          description: 'The unique identifier of the thread to close (e.g., "789012")',
+          description: PARAM_DESCRIPTIONS.thread_id,
         },
         message: {
           type: 'string',
-          description:
-            'Optional closing message to add to the thread. If not provided, defaults to "Thread closed"',
+          description: PARAM_DESCRIPTIONS.message,
         },
       },
       required: ['thread_id'],

--- a/experimental/twist/shared/src/tools/create-thread.ts
+++ b/experimental/twist/shared/src/tools/create-thread.ts
@@ -2,26 +2,24 @@ import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { z } from 'zod';
 import type { ClientFactory } from '../server.js';
 
+// Parameter descriptions - single source of truth
+const PARAM_DESCRIPTIONS = {
+  channel_id:
+    'The unique identifier of the channel where the thread will be created (e.g., "123456"). Use get_channels to find channel IDs',
+  title:
+    'A descriptive title for the thread (e.g., "Q4 Planning Discussion" or "Bug Report: Login Issues"). Keep it concise but informative',
+  content:
+    'The first message in the thread. This sets the context for the discussion. Supports basic formatting like line breaks',
+} as const;
+
 /**
  * Tool for creating a new thread in a channel
  */
 export function createThreadTool(server: Server, clientFactory: ClientFactory) {
   const CreateThreadSchema = z.object({
-    channel_id: z
-      .string()
-      .describe(
-        'The unique identifier of the channel where the thread will be created (e.g., "123456"). Use get_channels to find channel IDs'
-      ),
-    title: z
-      .string()
-      .describe(
-        'A descriptive title for the thread (e.g., "Q4 Planning Discussion" or "Bug Report: Login Issues"). Keep it concise but informative'
-      ),
-    content: z
-      .string()
-      .describe(
-        'The first message in the thread. This sets the context for the discussion. Supports basic formatting like line breaks'
-      ),
+    channel_id: z.string().describe(PARAM_DESCRIPTIONS.channel_id),
+    title: z.string().describe(PARAM_DESCRIPTIONS.title),
+    content: z.string().describe(PARAM_DESCRIPTIONS.content),
   });
 
   return {
@@ -49,18 +47,15 @@ Use cases:
       properties: {
         channel_id: {
           type: 'string',
-          description:
-            'The unique identifier of the channel where the thread will be created (e.g., "123456"). Use get_channels to find channel IDs',
+          description: PARAM_DESCRIPTIONS.channel_id,
         },
         title: {
           type: 'string',
-          description:
-            'A descriptive title for the thread (e.g., "Q4 Planning Discussion" or "Bug Report: Login Issues"). Keep it concise but informative',
+          description: PARAM_DESCRIPTIONS.title,
         },
         content: {
           type: 'string',
-          description:
-            'The first message in the thread. This sets the context for the discussion. Supports basic formatting like line breaks',
+          description: PARAM_DESCRIPTIONS.content,
         },
       },
       required: ['channel_id', 'title', 'content'],

--- a/experimental/twist/shared/src/tools/get-channel.ts
+++ b/experimental/twist/shared/src/tools/get-channel.ts
@@ -2,48 +2,40 @@ import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { z } from 'zod';
 import type { ClientFactory, Thread } from '../server.js';
 
+// Parameter descriptions (single source of truth)
+const PARAM_DESCRIPTIONS = {
+  channel_id:
+    'The unique identifier of the channel (e.g., "123456"). Use get_channels to find channel IDs',
+  include_threads: 'Whether to include threads in the channel (default: true)',
+  threads_limit:
+    'Maximum number of threads to return when include_threads is true (default: 10, max: 100)',
+  threads_offset:
+    'Number of threads to skip for pagination when include_threads is true (e.g., offset: 50 to get the next page after first 50)',
+  include_closed_threads:
+    'Whether to include closed threads in the results when include_threads is true (default: false, only shows open threads)',
+  threads_newer_than_ts:
+    'Unix timestamp in seconds to filter threads created after this time when include_threads is true (e.g., 1704067200 for Jan 1, 2024)',
+} as const;
+
 /**
  * Tool for getting details about a specific channel
  */
 export function getChannelTool(server: Server, clientFactory: ClientFactory) {
   const GetChannelSchema = z.object({
-    channel_id: z
-      .string()
-      .describe(
-        'The unique identifier of the channel (e.g., "123456"). Use get_channels to find channel IDs'
-      ),
+    channel_id: z.string().describe(PARAM_DESCRIPTIONS.channel_id),
     include_threads: z
       .boolean()
       .optional()
       .default(true)
-      .describe('Whether to include threads in the channel (default: true)'),
-    threads_limit: z
-      .number()
-      .optional()
-      .default(10)
-      .describe(
-        'Maximum number of threads to return when include_threads is true (default: 10, max: 100)'
-      ),
-    threads_offset: z
-      .number()
-      .optional()
-      .default(0)
-      .describe(
-        'Number of threads to skip for pagination when include_threads is true (e.g., offset: 50 to get the next page after first 50)'
-      ),
+      .describe(PARAM_DESCRIPTIONS.include_threads),
+    threads_limit: z.number().optional().default(10).describe(PARAM_DESCRIPTIONS.threads_limit),
+    threads_offset: z.number().optional().default(0).describe(PARAM_DESCRIPTIONS.threads_offset),
     include_closed_threads: z
       .boolean()
       .optional()
       .default(false)
-      .describe(
-        'Whether to include closed threads in the results when include_threads is true (default: false, only shows open threads)'
-      ),
-    threads_newer_than_ts: z
-      .number()
-      .optional()
-      .describe(
-        'Unix timestamp in seconds to filter threads created after this time when include_threads is true (e.g., 1704067200 for Jan 1, 2024)'
-      ),
+      .describe(PARAM_DESCRIPTIONS.include_closed_threads),
+    threads_newer_than_ts: z.number().optional().describe(PARAM_DESCRIPTIONS.threads_newer_than_ts),
   });
 
   return {
@@ -76,36 +68,31 @@ Use cases:
       properties: {
         channel_id: {
           type: 'string',
-          description:
-            'The unique identifier of the channel (e.g., "123456"). Use get_channels to find channel IDs',
+          description: PARAM_DESCRIPTIONS.channel_id,
         },
         include_threads: {
           type: 'boolean',
-          description: 'Whether to include threads in the channel (default: true)',
+          description: PARAM_DESCRIPTIONS.include_threads,
           default: true,
         },
         threads_limit: {
           type: 'number',
-          description:
-            'Maximum number of threads to return when include_threads is true (default: 10, max: 100)',
+          description: PARAM_DESCRIPTIONS.threads_limit,
           default: 10,
         },
         threads_offset: {
           type: 'number',
-          description:
-            'Number of threads to skip for pagination when include_threads is true (e.g., offset: 50 to get the next page after first 50)',
+          description: PARAM_DESCRIPTIONS.threads_offset,
           default: 0,
         },
         include_closed_threads: {
           type: 'boolean',
-          description:
-            'Whether to include closed threads in the results when include_threads is true (default: false, only shows open threads)',
+          description: PARAM_DESCRIPTIONS.include_closed_threads,
           default: false,
         },
         threads_newer_than_ts: {
           type: 'number',
-          description:
-            'Unix timestamp in seconds to filter threads created after this time when include_threads is true (e.g., 1704067200 for Jan 1, 2024)',
+          description: PARAM_DESCRIPTIONS.threads_newer_than_ts,
         },
       },
       required: ['channel_id'],

--- a/experimental/twist/shared/src/tools/get-thread.ts
+++ b/experimental/twist/shared/src/tools/get-thread.ts
@@ -2,28 +2,23 @@ import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { z } from 'zod';
 import type { ClientFactory } from '../server.js';
 
+// Parameter descriptions (single source of truth)
+const PARAM_DESCRIPTIONS = {
+  thread_id:
+    'The unique identifier of the thread (e.g., "789012"). Use get_threads to find thread IDs',
+  message_limit: 'Maximum number of recent messages to return (default: 10, max: 100)',
+  message_offset:
+    'Number of messages to skip from the end for pagination (e.g., offset: 10 to get older messages)',
+} as const;
+
 /**
  * Tool for getting a thread with all its messages
  */
 export function getThreadTool(server: Server, clientFactory: ClientFactory) {
   const GetThreadSchema = z.object({
-    thread_id: z
-      .string()
-      .describe(
-        'The unique identifier of the thread (e.g., "789012"). Use get_threads to find thread IDs'
-      ),
-    message_limit: z
-      .number()
-      .optional()
-      .default(10)
-      .describe('Maximum number of recent messages to return (default: 10, max: 100)'),
-    message_offset: z
-      .number()
-      .optional()
-      .default(0)
-      .describe(
-        'Number of messages to skip from the end for pagination (e.g., offset: 10 to get older messages)'
-      ),
+    thread_id: z.string().describe(PARAM_DESCRIPTIONS.thread_id),
+    message_limit: z.number().optional().default(10).describe(PARAM_DESCRIPTIONS.message_limit),
+    message_offset: z.number().optional().default(0).describe(PARAM_DESCRIPTIONS.message_offset),
   });
 
   return {
@@ -62,18 +57,16 @@ Use cases:
       properties: {
         thread_id: {
           type: 'string',
-          description:
-            'The unique identifier of the thread (e.g., "789012"). Use get_threads to find thread IDs',
+          description: PARAM_DESCRIPTIONS.thread_id,
         },
         message_limit: {
           type: 'number',
-          description: 'Maximum number of recent messages to return (default: 10, max: 100)',
+          description: PARAM_DESCRIPTIONS.message_limit,
           default: 10,
         },
         message_offset: {
           type: 'number',
-          description:
-            'Number of messages to skip from the end for pagination (e.g., offset: 10 to get older messages)',
+          description: PARAM_DESCRIPTIONS.message_offset,
           default: 0,
         },
       },

--- a/mcp-server-template/shared/src/tools/example-tool.ts
+++ b/mcp-server-template/shared/src/tools/example-tool.ts
@@ -2,9 +2,14 @@ import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { z } from 'zod';
 import { IExampleClient } from '../example-client/example-client.js';
 
+// Parameter descriptions - single source of truth
+const PARAM_DESCRIPTIONS = {
+  message: 'The message to process',
+} as const;
+
 // Schema for tool input validation
 export const ExampleToolSchema = z.object({
-  message: z.string().describe('The message to process'),
+  message: z.string().describe(PARAM_DESCRIPTIONS.message),
 });
 
 /**
@@ -24,7 +29,7 @@ export function exampleTool(_server: Server, _clientFactory: () => IExampleClien
       properties: {
         message: {
           type: 'string',
-          description: 'The message to process',
+          description: PARAM_DESCRIPTIONS.message,
         },
       },
       required: ['message'],

--- a/productionized/pulse-fetch/CHANGELOG.md
+++ b/productionized/pulse-fetch/CHANGELOG.md
@@ -27,6 +27,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Different extraction queries on the same URL will no longer return incorrect cached results
   - Added new `findByUrlAndExtract` method to storage interfaces for proper cache key generation
   - Added comprehensive test coverage for extract field cache busting functionality
+- Updated `cleanScrape` parameter description to more accurately describe its function
+  - Changed from "converting HTML to Markdown" to "converting HTML to semantic Markdown of what's on the page"
+  - Better reflects that the cleaning process extracts meaningful content, not just format conversion
+- Made tool parameter descriptions DRY (Don't Repeat Yourself) using PARAM_DESCRIPTIONS constant
+  - Eliminates duplication between Zod schema and inputSchema descriptions
 
 ### Changed
 
@@ -34,6 +39,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `BRIGHTDATA_BEARER_TOKEN` → `BRIGHTDATA_API_KEY` (users no longer need to include "Bearer " prefix)
   - `PULSE_FETCH_STRATEGY_CONFIG_PATH` → `STRATEGY_CONFIG_PATH`
   - Updated all documentation, tests, and examples to reflect the new names
+
+### Known Issues
+
+- MCP client timeout errors (-32001) cannot be configured from the server side
+  - The MCP protocol timeout is controlled by the client (Claude), not the server
+  - Current workaround: Use the timeout parameter to control individual HTTP request timeouts
+  - This is a protocol limitation, not a server bug
 
 ## [0.2.7] - 2025-07-03
 


### PR DESCRIPTION
## Summary
- Fixed cleanScrape description in pulse-fetch to accurately say "semantic Markdown of what's on the page"
- Made parameter descriptions DRY (Don't Repeat Yourself) across all MCP servers using PARAM_DESCRIPTIONS constants
- Modernized AppSignal from deprecated server.tool() to server.registerTool() pattern

## Test plan
- [ ] Verify all modified servers build successfully
- [ ] Test pulse-fetch scrape tool to ensure cleanScrape parameter works correctly
- [ ] Verify AppSignal tools continue to function with the new registerTool pattern
- [ ] Check that parameter descriptions appear correctly in tool schemas
- [ ] Ensure CI passes all tests

🤖 Generated with [Claude Code](https://claude.ai/code)