### PR TITLE
chore(appsignal): bump version to 0.2.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ These are high-quality servers that we may discontinue if the official provider 
 
 | Name                                   | Description                                                     | Local Status | Remote Status | Target Audience                                       | Notes                                                                |
 | -------------------------------------- | --------------------------------------------------------------- | ------------ | ------------- | ----------------------------------------------------- | -------------------------------------------------------------------- |
-| [appsignal](./experimental/appsignal/) | AppSignal application performance monitoring and error tracking | 0.2.10       | Not Started   | Developers using AppSignal for application monitoring | Requires AppSignal API key; NOT officially affiliated with AppSignal |
+| [appsignal](./experimental/appsignal/) | AppSignal application performance monitoring and error tracking | 0.2.11       | Not Started   | Developers using AppSignal for application monitoring | Requires AppSignal API key; NOT officially affiliated with AppSignal |
 | [twist](./experimental/twist/)         | Twist team messaging and collaboration platform integration     | 0.1.15       | Not Started   | Teams using Twist for asynchronous communication      | Requires Twist API bearer token and workspace ID                     |
 
 ## Contributing

--- a/experimental/appsignal/CHANGELOG.md
+++ b/experimental/appsignal/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.11] - 2025-07-03
+
 ### Changed
 
 - Applied DRY (Don't Repeat Yourself) pattern to all tool parameter descriptions
@@ -14,6 +16,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - All 14 tool files now use consistent parameter descriptions
   - Separated Zod shape definitions from schema objects for better organization
   - Improves maintainability by eliminating description duplication
+
+### Fixed
+
+- Fixed integration test imports to use relative paths instead of package names
+  - Updated `index.integration-with-mock.ts` to use '../shared/index.js' pattern
+  - Follows monorepo workspace setup requirements for proper module resolution
 
 ## [0.2.10] - 2025-07-03
 

--- a/experimental/appsignal/local/package.json
+++ b/experimental/appsignal/local/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appsignal-mcp-server",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "description": "Local implementation of AppSignal MCP server",
   "main": "build/index.js",
   "type": "module",

--- a/experimental/appsignal/local/src/index.integration-with-mock.ts
+++ b/experimental/appsignal/local/src/index.integration-with-mock.ts
@@ -8,8 +8,8 @@
  * Mock data is passed via the APPSIGNAL_MOCK_DATA environment variable.
  */
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
-import { createMCPServer } from 'appsignal-mcp-server-shared';
-import { createIntegrationMockAppsignalClient } from 'appsignal-mcp-server-shared/build/appsignal-client/appsignal-client.integration-mock.js';
+import { createMCPServer } from '../shared/index.js';
+import { createIntegrationMockAppsignalClient } from '../shared/appsignal-client/appsignal-client.integration-mock.js';
 
 async function main() {
   const transport = new StdioServerTransport();

--- a/experimental/appsignal/package-lock.json
+++ b/experimental/appsignal/package-lock.json
@@ -36,7 +36,7 @@
     },
     "local": {
       "name": "appsignal-mcp-server",
-      "version": "0.2.10",
+      "version": "0.2.11",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.13.2",

--- a/experimental/appsignal/tests/manual/appsignal-new-tools.manual.test.ts
+++ b/experimental/appsignal/tests/manual/appsignal-new-tools.manual.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { TestMCPClient } from '../../../../test-mcp-client/build/index.js';
 import path from 'path';
 import { fileURLToPath } from 'url';
+import 'dotenv/config';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);

--- a/experimental/appsignal/tests/manual/appsignal.manual.test.ts
+++ b/experimental/appsignal/tests/manual/appsignal.manual.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { TestMCPClient } from '../../../../test-mcp-client/build/index.js';
 import path from 'path';
 import { fileURLToPath } from 'url';
+import 'dotenv/config';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);

--- a/experimental/appsignal/tests/manual/performance-tools.manual.test.ts
+++ b/experimental/appsignal/tests/manual/performance-tools.manual.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { TestMCPClient } from '../../../../test-mcp-client/build/index.js';
 import path from 'path';
 import { fileURLToPath } from 'url';
+import 'dotenv/config';
 import type { TimelineEvent } from '../../shared/src/appsignal-client/lib/performance-incident-sample-timeline.js';
 
 const __filename = fileURLToPath(import.meta.url);

--- a/experimental/appsignal/vitest.config.manual.ts
+++ b/experimental/appsignal/vitest.config.manual.ts
@@ -1,17 +1,9 @@
 import { defineConfig } from 'vitest/config';
-import path from 'path';
 
 export default defineConfig({
   test: {
-    globals: true,
-    environment: 'node',
     include: ['tests/manual/**/*.test.ts'],
-    testTimeout: 60000, // Manual tests may take longer due to real API calls
-    setupFiles: ['dotenv/config'], // Load .env file
-  },
-  resolve: {
-    alias: {
-      '@': path.resolve(__dirname, './shared/src'),
-    },
+    testTimeout: 60000,
+    hookTimeout: 30000,
   },
 });


### PR DESCRIPTION
## Summary
- Bumped AppSignal MCP server version from 0.2.10 to 0.2.11
- Applied DRY pattern to tool parameter descriptions
- Fixed integration test imports to use relative paths
- Fixed manual test configuration and all tests now pass

## Changes
- Version bump for appsignal-mcp-server to 0.2.11
- Applied DRY (Don't Repeat Yourself) pattern to all tool parameter descriptions
- Fixed integration test imports to use '../shared/index.js' pattern
- Simplified vitest configuration to match pulse-fetch pattern
- Fixed TypeScript type issues in tests
- Updated tests to gracefully handle missing/deleted incidents

## Test plan
- [x] Built successfully
- [x] Linting passed
- [x] Manual tests passed (8/8 tests passing)
- [x] Updated CHANGELOG.md
- [x] Updated README.md version table

🤖 Generated with [Claude Code](https://claude.ai/code)