### PR TITLE
fix: correct CHANGELOG path in publish workflow and manage latest tag for monorepo

### DIFF
--- a/.github/workflows/publish-mcp-servers.yml
+++ b/.github/workflows/publish-mcp-servers.yml
@@ -253,7 +253,8 @@ jobs:
                 SERVER_NAME=$(basename "$SERVER_DIR")
                 
                 # Extract changelog entry for this version
-                CHANGELOG_FILE="$SERVER_DIR/CHANGELOG.md"
+                # Since we're in the local directory, we need to go up one level to find CHANGELOG.md
+                CHANGELOG_FILE="../CHANGELOG.md"
                 if [ -f "$CHANGELOG_FILE" ]; then
                   # Extract the changelog section for this version
                   # Look for version with or without 'v' prefix and handle both formats


### PR DESCRIPTION
## Summary

This PR fixes two issues with releases in our monorepo:

1. **Fixed CHANGELOG path issue**: The publish workflow was trying to access `CHANGELOG.md` using an incorrect path after changing into the `local` directory. Updated to use `../CHANGELOG.md` to properly include changelog content in GitHub releases.

2. **Solved the "latest" tag problem**: Created a dummy placeholder release (`monorepo-latest-placeholder@0.0.0`) that holds the "latest" tag, preventing individual package releases from being incorrectly marked as the repository's latest release.

## Changes

- Updated `.github/workflows/publish-mcp-servers.yml` to use correct relative path for CHANGELOG files
- Created a placeholder release to properly manage the "latest" tag in our monorepo

## Testing

- The workflow fix will be tested when the next package version is published
- The placeholder release is already live and successfully holding the "latest" tag

## Context

Previously, release notes were showing generic text instead of changelog content because the workflow couldn't find the CHANGELOG file. Additionally, GitHub was automatically assigning the "latest" tag to package releases, which doesn't make sense in a monorepo context where multiple independent packages exist.