### PR TITLE
feat(pulse-fetch): make URL parameter more forgiving

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "mcp-servers-monorepo",
       "version": "1.0.0",
       "devDependencies": {
+        "@types/jsdom": "^21.1.7",
         "@typescript-eslint/eslint-plugin": "^8.19.0",
         "@typescript-eslint/parser": "^8.19.0",
         "eslint": "^8.57.0",
@@ -213,6 +214,32 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/@types/jsdom": {
+      "version": "21.1.7",
+      "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-21.1.7.tgz",
+      "integrity": "sha512-yOriVnggzrnQ3a9OKOCxaVuSug3w3/SbOj5i7VwXWZEyUNl3bLF9V3MfxGbZKuwqJOQyRfqXyROBB1CoZLFWzA==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*",
+        "@types/tough-cookie": "*",
+        "parse5": "^7.0.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "24.0.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.10.tgz",
+      "integrity": "sha512-ENHwaH+JIRTDIEEbDK6QSQntAYGtbvdDXnMXnZaZ6k13Du1dPMmprkEHIL7ok2Wl2aZevetwTAb5S+7yIF+enA==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~7.8.0"
+      }
+    },
+    "node_modules/@types/tough-cookie": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
+      "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
+      "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.35.0",
@@ -737,6 +764,18 @@
       "integrity": "sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/environment": {
       "version": "1.1.0",
@@ -1855,6 +1894,18 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -2331,6 +2382,12 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
+      "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
+      "dev": true
     },
     "node_modules/uri-js": {
       "version": "4.4.1",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "clean": "rm -rf experimental/**/build experimental/**/dist productionized/**/build productionized/**/dist"
   },
   "devDependencies": {
+    "@types/jsdom": "^21.1.7",
     "@typescript-eslint/eslint-plugin": "^8.19.0",
     "@typescript-eslint/parser": "^8.19.0",
     "eslint": "^8.57.0",

--- a/productionized/pulse-fetch/CHANGELOG.md
+++ b/productionized/pulse-fetch/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to the Pulse Fetch MCP server will be documented in this fil
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Improved
+
+- Made URL parameter more forgiving in the scrape tool
+  - URLs without protocol (e.g., `example.com`) now automatically get `https://` prefix
+  - Whitespace is automatically trimmed from URLs (prevents issues with trailing newlines or spaces)
+  - Added comprehensive functional test coverage for URL preprocessing behavior
+  - URLs with existing protocols (http://, ftp://, custom://) are preserved as-is
+
 ## [0.2.9] - 2025-07-03
 
 ### Fixed

--- a/productionized/pulse-fetch/README.md
+++ b/productionized/pulse-fetch/README.md
@@ -332,7 +332,7 @@ Disable cleaning (`cleanScrape: false`) only when:
 
 **Parameters:**
 
-- `url` (string, required): URL to scrape
+- `url` (string, required): URL to scrape (e.g., "https://example.com" or just "example.com" - https:// is added automatically if no protocol is specified)
 - `timeout` (number): Maximum time to wait for page load
 - `maxChars` (number): Maximum characters to return (default: 100,000)
 - `startIndex` (number): Character index to start output from (for pagination)

--- a/productionized/pulse-fetch/shared/src/tools/scrape.ts
+++ b/productionized/pulse-fetch/shared/src/tools/scrape.ts
@@ -79,10 +79,27 @@ Complex queries:
 The LLM will intelligently parse the page content and return only the requested information in a clear, readable format.`,
 } as const;
 
+// Preprocess URL to make it more forgiving
+function preprocessUrl(url: string): string {
+  // Trim whitespace
+  url = url.trim();
+
+  // If no protocol is specified, add https://
+  if (!url.match(/^[a-zA-Z][a-zA-Z0-9+.-]*:/)) {
+    url = 'https://' + url;
+  }
+
+  return url;
+}
+
 // Build the schema dynamically based on available features
 const buildScrapeArgsSchema = () => {
   const baseSchema = {
-    url: z.string().url().describe(PARAM_DESCRIPTIONS.url),
+    url: z
+      .string()
+      .transform(preprocessUrl)
+      .pipe(z.string().url())
+      .describe(PARAM_DESCRIPTIONS.url),
     timeout: z.number().optional().default(60000).describe(PARAM_DESCRIPTIONS.timeout),
     maxChars: z.number().optional().default(100000).describe(PARAM_DESCRIPTIONS.maxChars),
     startIndex: z.number().optional().default(0).describe(PARAM_DESCRIPTIONS.startIndex),


### PR DESCRIPTION
## Summary
- Automatically adds `https://` to URLs without a protocol (e.g., `example.com` → `https://example.com`)
- Trims whitespace from URLs to prevent issues with trailing newlines or spaces
- Preserves existing protocols (http://, ftp://, custom://, etc.)

## Changes
- Added `preprocessUrl` function to handle URL preprocessing before validation
- Integrated preprocessing into Zod schema using `.transform()` and `.pipe()`
- Added comprehensive functional test coverage (6 new test cases)
- Updated documentation to clarify URL parameter accepts both formats

## Test plan
- [x] Run functional tests with `npm test -- tests/functional/scrape-tool.test.ts`
- [x] Verify all 27 tests pass
- [x] Manual testing with various URL formats

🤖 Generated with [Claude Code](https://claude.ai/code)