### PR TITLE
Publish appsignal-mcp-server@0.2.14

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ These are high-quality servers that we may discontinue if the official provider 
 
 | Name                                   | Description                                                     | Local Status | Remote Status | Target Audience                                       | Notes                                                                |
 | -------------------------------------- | --------------------------------------------------------------- | ------------ | ------------- | ----------------------------------------------------- | -------------------------------------------------------------------- |
-| [appsignal](./experimental/appsignal/) | AppSignal application performance monitoring and error tracking | 0.2.13       | Not Started   | Developers using AppSignal for application monitoring | Requires AppSignal API key; NOT officially affiliated with AppSignal |
+| [appsignal](./experimental/appsignal/) | AppSignal application performance monitoring and error tracking | 0.2.14       | Not Started   | Developers using AppSignal for application monitoring | Requires AppSignal API key; NOT officially affiliated with AppSignal |
 | [twist](./experimental/twist/)         | Twist team messaging and collaboration platform integration     | 0.1.17       | Not Started   | Teams using Twist for asynchronous communication      | Requires Twist API bearer token and workspace ID                     |
 
 ## Contributing

--- a/experimental/appsignal/CHANGELOG.md
+++ b/experimental/appsignal/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.14] - 2025-07-07
+
 ### Fixed
 
 - Fixed search_logs returning 400 errors when using `start` and `end` parameters. Implemented a workaround for an AppSignal API bug where these parameters cause 400 errors when passed as GraphQL variables. The parameters now work correctly by being hardcoded in the query string, allowing users to filter logs by time range.

--- a/experimental/appsignal/MANUAL_TESTING.md
+++ b/experimental/appsignal/MANUAL_TESTING.md
@@ -62,9 +62,9 @@ The tests will:
 
 ## Latest Test Results
 
-**Test Date:** 2025-07-07 13:12 PT  
-**Branch:** tadasant/appsignal-400-error  
-**Commit:** 38eff1c  
+**Test Date:** 2025-07-07 13:48 PT  
+**Branch:** tadasant/bump-appsignal  
+**Commit:** 39202f6  
 **Tested By:** Claude  
 **Environment:** Local development with API keys from .env
 
@@ -81,7 +81,7 @@ The tests will:
 - ✅ appsignal.manual.test.ts: 1/1 tests passed
   - Core workflow tested successfully with pulsemcp app
   - Found 10 log entries in search test
-  - Log search now works correctly (no more 400 errors)
+  - Log search works correctly
 - ✅ performance-tools.manual.test.ts: 4/4 tests passed
   - Error handling verified
   - No performance incidents found in test app (warning state)
@@ -90,16 +90,14 @@ The tests will:
   - Found 4 OPEN performance incidents
   - State handling verified (empty states defaults to OPEN)
 - ✅ search-logs-400.manual.test.ts: 1/1 tests passed
-  - **VERIFIED FIX**: All parameter combinations work without 400 errors
+  - All parameter combinations work without errors
   - Tested with empty severities, explicit severities, and empty query
 
 **Notable Findings:**
 
-- **FIXED**: Log search API no longer returns 400 errors
-  - Root cause: AppSignal GraphQL API doesn't accept `start` and `end` parameters in the `lines` field
-  - Solution: Removed these parameters from the GraphQL query while keeping them in function signature
+- Log search API working correctly with all parameter combinations
 - AppSignal doesn't provide incident listing endpoints
 - Performance incident data available in production app (pulsemcp)
 - Empty states array correctly defaults to OPEN state
 
-**Summary:** All manual tests passed successfully. The search_logs 400 error has been fixed by removing the unsupported `start` and `end` parameters from the GraphQL query. The AppSignal MCP server is now working correctly with all features functional.
+**Summary:** All manual tests passed successfully. The AppSignal MCP server is working correctly with all features functional.

--- a/experimental/appsignal/local/package.json
+++ b/experimental/appsignal/local/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appsignal-mcp-server",
-  "version": "0.2.13",
+  "version": "0.2.14",
   "description": "Local implementation of AppSignal MCP server",
   "main": "build/index.js",
   "type": "module",

--- a/experimental/appsignal/package-lock.json
+++ b/experimental/appsignal/package-lock.json
@@ -36,7 +36,7 @@
     },
     "local": {
       "name": "appsignal-mcp-server",
-      "version": "0.2.13",
+      "version": "0.2.14",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.13.2",

--- a/experimental/appsignal/package-lock.json
+++ b/experimental/appsignal/package-lock.json
@@ -21,7 +21,7 @@
         "dotenv": "^16.5.0",
         "dotenv-cli": "^8.0.0",
         "graphql": "^16.11.0",
-        "vitest": "^3.2.3"
+        "vitest": "^3.2.4"
       },
       "optionalDependencies": {
         "@rollup/rollup-darwin-arm64": "^4.9.5",
@@ -6674,7 +6674,6 @@
       "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
       "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.4",

--- a/experimental/appsignal/package.json
+++ b/experimental/appsignal/package.json
@@ -43,7 +43,7 @@
     "dotenv": "^16.5.0",
     "dotenv-cli": "^8.0.0",
     "graphql": "^16.11.0",
-    "vitest": "^3.2.3"
+    "vitest": "^3.2.4"
   },
   "optionalDependencies": {
     "@rollup/rollup-darwin-arm64": "^4.9.5",


### PR DESCRIPTION
## Summary

Publishing AppSignal MCP server version 0.2.14 with critical bug fix for search_logs 400 errors.

## Changes

### Fixed
- Fixed search_logs returning 400 errors when using `start` and `end` parameters
- Implemented workaround for AppSignal API bug where these parameters cause 400 errors when passed as GraphQL variables
- The parameters now work correctly by being hardcoded in the query string

### Added
- Manual test coverage specifically for the search_logs 400 error scenario
- Setup script (`test:manual:setup`) for easier manual testing environment preparation

### Improved
- Documentation for manual testing setup in new worktrees
- Monorepo workspace configuration for better dependency management

## Additional Changes

- Enhanced `bin/gw.sh` with robust npm installation that automatically cleans node_modules on failure
- This prevents module resolution issues in monorepo workspaces

## Checklist

- [x] Version bumped in package.json (0.2.13 → 0.2.14)
- [x] CHANGELOG.md updated with new version section
- [x] All tests passing
- [x] Manual tests run and MANUAL_TESTING.md updated
- [x] Git tag created (appsignal-mcp-server@0.2.14)
- [x] Main README.md updated with new version number
- [x] No sensitive information in code

## Manual Test Results

- **Test Date:** 2025-07-07 13:48 PT
- **Overall:** 9/9 tests passed (100%)
- **Key Fix Verified:** search_logs now works with all parameter combinations without 400 errors