### PR TITLE
fix: remove duplicate header in GitHub release notes

### DIFF
--- a/.github/workflows/publish-mcp-servers.yml
+++ b/.github/workflows/publish-mcp-servers.yml
@@ -262,12 +262,12 @@ jobs:
                   
                   if [ -z "$CHANGELOG_ENTRY" ]; then
                     echo "Warning: No changelog entry found for version $PACKAGE_VERSION"
-                    RELEASE_NOTES="# $PACKAGE_NAME v$PACKAGE_VERSION"$'\n\n'"Published to npm: https://www.npmjs.com/package/$PACKAGE_NAME"
+                    RELEASE_NOTES="Published to npm: https://www.npmjs.com/package/$PACKAGE_NAME"
                   else
-                    RELEASE_NOTES="# $PACKAGE_NAME v$PACKAGE_VERSION"$'\n\n'"$CHANGELOG_ENTRY"$'\n\n'"---"$'\n'"Published to npm: https://www.npmjs.com/package/$PACKAGE_NAME"
+                    RELEASE_NOTES="$CHANGELOG_ENTRY"$'\n\n'"---"$'\n'"Published to npm: https://www.npmjs.com/package/$PACKAGE_NAME"
                   fi
                 else
-                  RELEASE_NOTES="# $PACKAGE_NAME v$PACKAGE_VERSION"$'\n\n'"Published to npm: https://www.npmjs.com/package/$PACKAGE_NAME"
+                  RELEASE_NOTES="Published to npm: https://www.npmjs.com/package/$PACKAGE_NAME"
                 fi
                 
                 # Create release using GitHub CLI


### PR DESCRIPTION
## Summary
- Remove duplicate package name and version header from GitHub release body
- The header was appearing both as the release title and in the body, causing redundancy
- Now only the release title shows the package name and version

## Test plan
- [x] Verified the workflow changes remove the header from all three RELEASE_NOTES cases
- [ ] Next release will show only one header instead of duplicate

🤖 Generated with [Claude Code](https://claude.ai/code)