### PR TITLE
fix: add missing npm publishing scripts for pulsemcp-cms-admin

### DIFF
--- a/experimental/pulsemcp-cms-admin/local/prepare-publish.js
+++ b/experimental/pulsemcp-cms-admin/local/prepare-publish.js
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+import { cp, rm } from 'fs/promises';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { execSync } from 'child_process';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+async function prepare() {
+  console.log('Preparing for publish...');
+
+  // First, ensure TypeScript is available
+  console.log('Installing TypeScript for build...');
+  try {
+    execSync('npm install --no-save typescript @types/node', { stdio: 'inherit' });
+  } catch (e) {
+    console.error('Failed to install TypeScript:', e.message);
+    process.exit(1);
+  }
+
+  // Build shared directory first
+  const sharedDir = join(__dirname, '../shared');
+  console.log('Building shared directory...');
+  try {
+    execSync('npm install && npm run build', { cwd: sharedDir, stdio: 'inherit' });
+  } catch (e) {
+    console.error('Failed to build shared directory:', e.message);
+    process.exit(1);
+  }
+
+  // Set up the shared directory for the build
+  console.log('Setting up shared directory for build...');
+  try {
+    // Create a symlink for the build process (like setup-dev.js does)
+    await rm(join(__dirname, 'shared'), { recursive: true, force: true });
+    execSync(`node setup-dev.js`, { cwd: __dirname, stdio: 'inherit' });
+  } catch (e) {
+    console.error('Failed to set up shared directory:', e.message);
+    process.exit(1);
+  }
+
+  // Now build the local package
+  console.log('Building local package...');
+  try {
+    execSync('npx tsc && npx tsc -p tsconfig.integration.json', { stdio: 'inherit' });
+  } catch (e) {
+    console.error('Failed to build local package:', e.message);
+    process.exit(1);
+  }
+
+  // Clean up the symlink and copy the actual files for publishing
+  try {
+    await rm(join(__dirname, 'shared'), { recursive: true, force: true });
+  } catch (e) {
+    // Ignore if doesn't exist
+  }
+
+  // Copy the built shared files
+  await cp(join(__dirname, '../shared/build'), join(__dirname, 'shared'), { recursive: true });
+
+  console.log('Copied shared files to local package');
+}
+
+prepare().catch(console.error);

--- a/experimental/pulsemcp-cms-admin/scripts/prepare-npm-readme.js
+++ b/experimental/pulsemcp-cms-admin/scripts/prepare-npm-readme.js
@@ -1,0 +1,63 @@
+#!/usr/bin/env node
+
+import { readFileSync, writeFileSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+// Paths
+const mainReadmePath = join(__dirname, '..', 'README.md');
+const localReadmePath = join(__dirname, '..', 'local', 'README.md');
+const outputPath = join(__dirname, '..', 'local', 'README.md');
+
+try {
+  // Read both README files
+  let mainContent = readFileSync(mainReadmePath, 'utf-8');
+  const localContent = readFileSync(localReadmePath, 'utf-8');
+
+  // Add GitHub repo reference at the top
+  const repoNotice = `> **Note**: This package is part of the [MCP Servers](https://github.com/pulsemcp/mcp-servers) monorepo. For the latest updates and full source code, visit the [PulseMCP CMS Admin MCP Server directory](https://github.com/pulsemcp/mcp-servers/tree/main/experimental/pulsemcp-cms-admin).
+
+`;
+
+  // Insert repo notice after the title
+  const titleMatch = mainContent.match(/^#.*PulseMCP CMS Admin.*$/m);
+  if (titleMatch) {
+    const titleIndex = mainContent.indexOf(titleMatch[0]);
+    const titleEndIndex = titleIndex + titleMatch[0].length;
+    mainContent =
+      mainContent.substring(0, titleEndIndex) +
+      '\n\n' +
+      repoNotice +
+      mainContent.substring(titleEndIndex + 1);
+  }
+
+  // Extract the configuration section from local README
+  const configMatch = localContent.match(/## Configuration[\s\S]*$/m);
+  const localConfigSection = configMatch ? configMatch[0] : '';
+
+  // Find where to insert the local configuration
+  // Look for the Manual Setup section and insert the local config before it
+  const manualSetupIndex = mainContent.indexOf('### Manual Setup');
+
+  if (manualSetupIndex !== -1 && localConfigSection) {
+    // Find the beginning of the Manual Setup section content
+    const beforeManualSetup = mainContent.substring(0, manualSetupIndex);
+    const afterManualSetup = mainContent.substring(manualSetupIndex);
+
+    // Insert the local configuration section before Manual Setup
+    mainContent = beforeManualSetup + localConfigSection + '\n\n' + afterManualSetup;
+  }
+
+  // Write the combined README to local directory
+  writeFileSync(outputPath, mainContent);
+
+  console.log('✅ Successfully prepared README for npm publication');
+  console.log('   - Added GitHub repository reference');
+  console.log('   - Merged configuration sections from local README');
+} catch (error) {
+  console.error('❌ Error preparing README:', error);
+  process.exit(1);
+}

--- a/libs/mcp-server-template/CI_SETUP.md
+++ b/libs/mcp-server-template/CI_SETUP.md
@@ -51,3 +51,33 @@ npm run test:all
 - The monorepo CI will automatically pick up new servers in most cases
 - If CI fails, check that all your dependencies are properly installed
 - Ensure your server follows the same patterns as other servers in the repo
+
+## Required Files for NPM Publishing
+
+When adding a new server that will be published to npm, ensure these files exist:
+
+### 1. `local/prepare-publish.js`
+
+This script prepares the package for npm publication by:
+
+- Installing TypeScript for the build
+- Building the shared directory
+- Setting up symlinks for the build process
+- Building the local package
+- Copying shared files into the local package
+
+### 2. `scripts/prepare-npm-readme.js`
+
+This script prepares the README for npm by:
+
+- Combining the main README with local configuration sections
+- Adding a GitHub repository reference
+- Ensuring published packages have comprehensive documentation
+
+If these files are missing, the CI publish workflow will fail with errors like:
+
+```
+Error: Cannot find module '/path/to/local/prepare-publish.js'
+```
+
+You can copy these files from existing servers like `experimental/appsignal/` or `experimental/twist/` and update the server name references.


### PR DESCRIPTION
## Summary

This PR fixes the CI publish workflow failure for the pulsemcp-cms-admin server by adding the required npm publishing scripts.

## Problem

When the PR #154 was merged, the CI publish workflow failed with:
```
Error: Cannot find module '/home/runner/work/mcp-servers/mcp-servers/experimental/pulsemcp-cms-admin/local/prepare-publish.js'
```

## Solution

Added the two missing scripts required for npm publishing:

1. **`local/prepare-publish.js`** - Prepares the package for publication by:
   - Installing TypeScript for the build
   - Building the shared directory
   - Setting up symlinks for the build process
   - Building the local package
   - Copying shared files into the local package

2. **`scripts/prepare-npm-readme.js`** - Prepares the README for npm by:
   - Combining the main README with local configuration sections
   - Adding a GitHub repository reference
   - Ensuring published packages have comprehensive documentation

## Additional Changes

Updated `libs/mcp-server-template/CI_SETUP.md` to document these required files so this doesn't happen again with future servers.

## Testing

The scripts were copied from existing servers (appsignal/twist) and updated with the correct server name references. They follow the same pattern as all other published servers in the monorepo.