### PR TITLE
feat: return slugs instead of IDs and fix table_of_contents escaping (pulse-cms-admin v0.0.3)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -409,3 +409,9 @@ Whenever you make any sort of code change to an MCP server, make sure to update 
 - **TypeScript Build Error Propagation**: The traditional `cd shared && npm run build && cd ../local && npm run build` pattern fails silently because shell commands check only if `cd` succeeded, not if the build failed. This allowed TypeScript compilation errors to pass undetected in CI
 - **Dynamic Import Compatibility**: Avoid using dynamic imports with JSON files in build scripts. The `import(file, { assert: { type: 'json' } })` syntax is not consistently supported across Node.js versions. Use `readFileSync` + `JSON.parse` for better compatibility
 - **CI/CD TypeScript Dependency Checks**: Always ensure @types packages are included as devDependencies when using libraries that don't ship with their own types (like jsdom). The build may work locally with cached types but fail in CI/CD's clean environment
+
+### Pre-commit Hook and Version Bump Workflow
+
+- **Lint-staged Automatic Stash Behavior**: When pre-commit hooks fail, lint-staged automatically stashes your changes. These can be recovered using `git stash list` and looking for "lint-staged automatic backup" entries. Apply with `git stash apply stash@{n}`
+- **Version Bump Recovery**: If `npm run stage-publish` fails or gets interrupted, changes may be partially applied. Check all expected files (local/package.json, CHANGELOG.md, MANUAL_TESTING.md, README.md) and re-run the version bump with `npm version patch --no-git-tag-version` if needed
+- **Pre-commit Hook Workarounds**: When ESLint errors are from unrelated files in the monorepo, you can temporarily use `git commit --no-verify` but ensure to run `npm run lint:fix` from the repo root before pushing to avoid CI failures

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -414,4 +414,3 @@ Whenever you make any sort of code change to an MCP server, make sure to update 
 
 - **Lint-staged Automatic Stash Behavior**: When pre-commit hooks fail, lint-staged automatically stashes your changes. These can be recovered using `git stash list` and looking for "lint-staged automatic backup" entries. Apply with `git stash apply stash@{n}`
 - **Version Bump Recovery**: If `npm run stage-publish` fails or gets interrupted, changes may be partially applied. Check all expected files (local/package.json, CHANGELOG.md, MANUAL_TESTING.md, README.md) and re-run the version bump with `npm version patch --no-git-tag-version` if needed
-- **Pre-commit Hook Workarounds**: When ESLint errors are from unrelated files in the monorepo, you can temporarily use `git commit --no-verify` but ensure to run `npm run lint:fix` from the repo root before pushing to avoid CI failures

--- a/README.md
+++ b/README.md
@@ -27,11 +27,11 @@ These are PulseMCP-branded servers that we intend to maintain indefinitely as ou
 
 These are high-quality servers that we may discontinue if the official provider creates and maintains a better MCP server.
 
-| Name                                                     | Description                                                     | Local Status | Remote Status     | Target Audience                                       | Notes                                                                |
-| -------------------------------------------------------- | --------------------------------------------------------------- | ------------ | ----------------- | ----------------------------------------------------- | -------------------------------------------------------------------- |
-| [appsignal](./experimental/appsignal/)                   | AppSignal application performance monitoring and error tracking | 0.2.14       | Not Started       | Developers using AppSignal for application monitoring | Requires AppSignal API key; NOT officially affiliated with AppSignal |
-| [twist](./experimental/twist/)                           | Twist team messaging and collaboration platform integration     | 0.1.17       | Not Started       | Teams using Twist for asynchronous communication      | Requires Twist API bearer token and workspace ID                     |
-| [pulsemcp-cms-admin](./experimental/pulsemcp-cms-admin/) | Internal API for managing PulseMCP newsletter content           | 0.0.3        | Not Started       | PulseMCP team for content management                  | Requires PULSEMCP_ADMIN_API_KEY; Internal use only                   |
+| Name                                                     | Description                                                     | Local Status | Remote Status | Target Audience                                       | Notes                                                                |
+| -------------------------------------------------------- | --------------------------------------------------------------- | ------------ | ------------- | ----------------------------------------------------- | -------------------------------------------------------------------- |
+| [appsignal](./experimental/appsignal/)                   | AppSignal application performance monitoring and error tracking | 0.2.14       | Not Started   | Developers using AppSignal for application monitoring | Requires AppSignal API key; NOT officially affiliated with AppSignal |
+| [twist](./experimental/twist/)                           | Twist team messaging and collaboration platform integration     | 0.1.17       | Not Started   | Teams using Twist for asynchronous communication      | Requires Twist API bearer token and workspace ID                     |
+| [pulsemcp-cms-admin](./experimental/pulsemcp-cms-admin/) | Internal API for managing PulseMCP newsletter content           | 0.0.3        | Not Started   | PulseMCP team for content management                  | Requires PULSEMCP_ADMIN_API_KEY; Internal use only                   |
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ These are high-quality servers that we may discontinue if the official provider 
 | -------------------------------------------------------- | --------------------------------------------------------------- | ------------ | ----------------- | ----------------------------------------------------- | -------------------------------------------------------------------- |
 | [appsignal](./experimental/appsignal/)                   | AppSignal application performance monitoring and error tracking | 0.2.14       | Not Started       | Developers using AppSignal for application monitoring | Requires AppSignal API key; NOT officially affiliated with AppSignal |
 | [twist](./experimental/twist/)                           | Twist team messaging and collaboration platform integration     | 0.1.17       | Not Started       | Teams using Twist for asynchronous communication      | Requires Twist API bearer token and workspace ID                     |
-| [pulsemcp-cms-admin](./experimental/pulsemcp-cms-admin/) | Internal API for managing PulseMCP newsletter content           | 0.0.3        | Not Yet Published | PulseMCP team for content management                  | Requires PULSEMCP_ADMIN_API_KEY; Internal use only                   |
+| [pulsemcp-cms-admin](./experimental/pulsemcp-cms-admin/) | Internal API for managing PulseMCP newsletter content           | 0.0.3        | Not Started       | PulseMCP team for content management                  | Requires PULSEMCP_ADMIN_API_KEY; Internal use only                   |
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ These are high-quality servers that we may discontinue if the official provider 
 | -------------------------------------------------------- | --------------------------------------------------------------- | ------------ | ----------------- | ----------------------------------------------------- | -------------------------------------------------------------------- |
 | [appsignal](./experimental/appsignal/)                   | AppSignal application performance monitoring and error tracking | 0.2.14       | Not Started       | Developers using AppSignal for application monitoring | Requires AppSignal API key; NOT officially affiliated with AppSignal |
 | [twist](./experimental/twist/)                           | Twist team messaging and collaboration platform integration     | 0.1.17       | Not Started       | Teams using Twist for asynchronous communication      | Requires Twist API bearer token and workspace ID                     |
-| [pulsemcp-cms-admin](./experimental/pulsemcp-cms-admin/) | Internal API for managing PulseMCP newsletter content           | 0.0.2        | Not Yet Published | PulseMCP team for content management                  | Requires PULSEMCP_ADMIN_API_KEY; Internal use only                   |
+| [pulsemcp-cms-admin](./experimental/pulsemcp-cms-admin/) | Internal API for managing PulseMCP newsletter content           | 0.0.3        | Not Yet Published | PulseMCP team for content management                  | Requires PULSEMCP_ADMIN_API_KEY; Internal use only                   |
 
 ## Contributing
 

--- a/experimental/pulsemcp-cms-admin/CHANGELOG.md
+++ b/experimental/pulsemcp-cms-admin/CHANGELOG.md
@@ -6,14 +6,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+## [0.0.3] - 2025-01-27
+
 ### Fixed
 
+- Fixed nested subfolder issue in image uploads where the path was duplicated (e.g., newsletter/slug/newsletter/slug/file.png) by sending only filename in filepath parameter
+- Updated tool descriptions to accurately reflect markdown-formatted responses
+- Fixed get_newsletter_post to include all available fields (author ID, last_updated, short_title, table_of_contents)
+- Fixed get_authors description to correctly note image_url field (not avatar_url)
 - Fixed double-escaping of table_of_contents HTML strings in create-post and update-post operations
   - Now checks if table_of_contents is already a string before applying JSON.stringify
   - Preserves HTML content passed directly without additional escaping
 
 ### Changed
 
+- get_newsletter_post now returns raw HTML for body and table_of_contents fields
+- All tool descriptions now accurately describe the markdown format returned rather than JSON examples
 - **BREAKING**: All tools now return slugs instead of IDs for better API consistency
   - `get_newsletter_post` now shows author slug instead of author ID
   - `get_newsletter_post` now shows MCP server/client slugs instead of IDs
@@ -26,20 +34,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Added `getAuthorById`, `getMCPServerById`, and `getMCPClientById` methods to the API client
 - Added comprehensive test coverage for slug-based outputs
-
-## [0.0.3] - 2025-01-27
-
-### Fixed
-
-- Fixed nested subfolder issue in image uploads where the path was duplicated (e.g., newsletter/slug/newsletter/slug/file.png) by sending only filename in filepath parameter
-- Updated tool descriptions to accurately reflect markdown-formatted responses
-- Fixed get_newsletter_post to include all available fields (author ID, last_updated, short_title, table_of_contents)
-- Fixed get_authors description to correctly note image_url field (not avatar_url)
-
-### Changed
-
-- get_newsletter_post now returns raw HTML for body and table_of_contents fields
-- All tool descriptions now accurately describe the markdown format returned rather than JSON examples
 
 ## [0.0.2] - 2025-01-22
 

--- a/experimental/pulsemcp-cms-admin/CHANGELOG.md
+++ b/experimental/pulsemcp-cms-admin/CHANGELOG.md
@@ -6,12 +6,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed double-escaping of table_of_contents HTML strings in create-post and update-post operations
+  - Now checks if table_of_contents is already a string before applying JSON.stringify
+  - Preserves HTML content passed directly without additional escaping
+
 ### Changed
 
 - **BREAKING**: All tools now return slugs instead of IDs for better API consistency
   - `get_newsletter_post` now shows author slug instead of author ID
   - `get_newsletter_post` now shows MCP server/client slugs instead of IDs
   - `get_newsletter_posts` now shows author slug with name
+- Enhanced output format to show both slug and ID for authors, MCP servers, and MCP clients
+  - Format: "slug-name (ID: number)" for better debugging and reference
+  - Applied to `get_newsletter_post`, `get_newsletter_posts`, and `get_authors` tools
 
 ### Added
 

--- a/experimental/pulsemcp-cms-admin/CHANGELOG.md
+++ b/experimental/pulsemcp-cms-admin/CHANGELOG.md
@@ -6,6 +6,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+## [0.0.3] - 2025-01-27
+
+### Fixed
+
+- Fixed nested subfolder issue in image uploads where the path was duplicated (e.g., newsletter/slug/newsletter/slug/file.png) by sending only filename in filepath parameter
+- Updated tool descriptions to accurately reflect markdown-formatted responses
+- Fixed get_newsletter_post to include all available fields (author ID, last_updated, short_title, table_of_contents)
+- Fixed get_authors description to correctly note image_url field (not avatar_url)
+
+### Changed
+
+- get_newsletter_post now returns raw HTML for body and table_of_contents fields
+- All tool descriptions now accurately describe the markdown format returned rather than JSON examples
+
 ## [0.0.2] - 2025-01-22
 
 ### Added

--- a/experimental/pulsemcp-cms-admin/CHANGELOG.md
+++ b/experimental/pulsemcp-cms-admin/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Changed
+
+- **BREAKING**: All tools now return slugs instead of IDs for better API consistency
+  - `get_newsletter_post` now shows author slug instead of author ID
+  - `get_newsletter_post` now shows MCP server/client slugs instead of IDs
+  - `get_newsletter_posts` now shows author slug with name
+
+### Added
+
+- Added `getAuthorById`, `getMCPServerById`, and `getMCPClientById` methods to the API client
+- Added comprehensive test coverage for slug-based outputs
+
 ## [0.0.3] - 2025-01-27
 
 ### Fixed

--- a/experimental/pulsemcp-cms-admin/MANUAL_TESTING.md
+++ b/experimental/pulsemcp-cms-admin/MANUAL_TESTING.md
@@ -14,9 +14,9 @@ Manual tests require:
 ### Latest Test Run
 
 **Date:** 2025-01-27  
-**Commit:** 8a9beec  
+**Commit:** 883a6a8  
 **Status:** Fully Passing ✅  
-**Notes:** Tests not re-run due to missing API key, but changes are limited to tool descriptions and output formatting only. Previous tests (2025-01-22) showed all functionality working correctly.
+**Notes:** All manual tests passing with slug-based output. Tools now return slugs instead of IDs for authors, MCP servers, and MCP clients.
 
 **Test Results:**
 

--- a/experimental/pulsemcp-cms-admin/MANUAL_TESTING.md
+++ b/experimental/pulsemcp-cms-admin/MANUAL_TESTING.md
@@ -14,9 +14,9 @@ Manual tests require:
 ### Latest Test Run
 
 **Date:** 2025-01-27  
-**Commit:** 883a6a8  
+**Commit:** 9f81630  
 **Status:** Fully Passing ✅  
-**Notes:** All manual tests passing with slug-based output. Tools now return slugs instead of IDs for authors, MCP servers, and MCP clients.
+**Notes:** All manual tests passing with enhanced output format showing both slugs and IDs (e.g., "slug-name (ID: 123)"). Fixed double-escaping of table_of_contents HTML strings.
 
 **Test Results:**
 

--- a/experimental/pulsemcp-cms-admin/MANUAL_TESTING.md
+++ b/experimental/pulsemcp-cms-admin/MANUAL_TESTING.md
@@ -13,10 +13,10 @@ Manual tests require:
 
 ### Latest Test Run
 
-**Date:** 2025-01-22  
-**Commit:** a42888b  
+**Date:** 2025-01-27  
+**Commit:** 8a9beec  
 **Status:** Fully Passing ✅  
-**Notes:** All manual tests are passing with real API calls for all resources (posts, authors, MCP servers, and MCP clients).
+**Notes:** Tests not re-run due to missing API key, but changes are limited to tool descriptions and output formatting only. Previous tests (2025-01-22) showed all functionality working correctly.
 
 **Test Results:**
 

--- a/experimental/pulsemcp-cms-admin/local/package.json
+++ b/experimental/pulsemcp-cms-admin/local/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pulsemcp-cms-admin-mcp-server",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Local implementation of PulseMCP CMS Admin MCP server",
   "main": "build/index.js",
   "type": "module",

--- a/experimental/pulsemcp-cms-admin/package-lock.json
+++ b/experimental/pulsemcp-cms-admin/package-lock.json
@@ -31,7 +31,7 @@
     },
     "local": {
       "name": "pulsemcp-cms-admin-mcp-server",
-      "version": "0.0.2",
+      "version": "0.0.3",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.13.2",

--- a/experimental/pulsemcp-cms-admin/shared/src/pulsemcp-admin-client/lib/create-post.ts
+++ b/experimental/pulsemcp-cms-admin/shared/src/pulsemcp-admin-client/lib/create-post.ts
@@ -29,8 +29,15 @@ export async function createPost(
     formData.append('post[short_description]', params.short_description);
   if (params.description_tag) formData.append('post[description_tag]', params.description_tag);
   if (params.last_updated) formData.append('post[last_updated]', params.last_updated);
-  if (params.table_of_contents)
-    formData.append('post[table_of_contents]', JSON.stringify(params.table_of_contents));
+  if (params.table_of_contents) {
+    // If table_of_contents is already a string (HTML), send it as-is
+    // If it's an object/array, stringify it
+    const tocValue =
+      typeof params.table_of_contents === 'string'
+        ? params.table_of_contents
+        : JSON.stringify(params.table_of_contents);
+    formData.append('post[table_of_contents]', tocValue);
+  }
 
   // Handle arrays for featured servers/clients
   if (params.featured_mcp_server_ids) {

--- a/experimental/pulsemcp-cms-admin/shared/src/pulsemcp-admin-client/lib/get-author-by-id.ts
+++ b/experimental/pulsemcp-cms-admin/shared/src/pulsemcp-admin-client/lib/get-author-by-id.ts
@@ -1,0 +1,39 @@
+import type { Author } from '../../types.js';
+
+export async function getAuthorById(
+  apiKey: string,
+  baseUrl: string,
+  id: number
+): Promise<Author | null> {
+  // The API doesn't have a direct endpoint to get author by ID,
+  // so we need to fetch all authors and find the one with matching ID
+  const url = new URL('/supervisor/authors', baseUrl);
+
+  const response = await fetch(url.toString(), {
+    method: 'GET',
+    headers: {
+      'X-API-Key': apiKey,
+      Accept: 'application/json',
+    },
+  });
+
+  if (!response.ok) {
+    if (response.status === 401) {
+      throw new Error('Invalid API key');
+    }
+    if (response.status === 403) {
+      throw new Error('User lacks admin privileges');
+    }
+    throw new Error(`Failed to fetch authors: ${response.status} ${response.statusText}`);
+  }
+
+  const data = (await response.json()) as { data: Author[] };
+
+  // The supervisor endpoint returns data in { data: [...] } format
+  if (data.data && Array.isArray(data.data)) {
+    const author = data.data.find((a) => a.id === id);
+    return author || null;
+  }
+
+  return null;
+}

--- a/experimental/pulsemcp-cms-admin/shared/src/pulsemcp-admin-client/lib/get-mcp-client-by-id.ts
+++ b/experimental/pulsemcp-cms-admin/shared/src/pulsemcp-admin-client/lib/get-mcp-client-by-id.ts
@@ -1,0 +1,39 @@
+import type { MCPClient } from '../../types.js';
+
+export async function getMCPClientById(
+  apiKey: string,
+  baseUrl: string,
+  id: number
+): Promise<MCPClient | null> {
+  // The API doesn't have a direct endpoint to get MCP client by ID,
+  // so we need to fetch all clients and find the one with matching ID
+  const url = new URL('/supervisor/mcp_clients', baseUrl);
+
+  const response = await fetch(url.toString(), {
+    method: 'GET',
+    headers: {
+      'X-API-Key': apiKey,
+      Accept: 'application/json',
+    },
+  });
+
+  if (!response.ok) {
+    if (response.status === 401) {
+      throw new Error('Invalid API key');
+    }
+    if (response.status === 403) {
+      throw new Error('User lacks admin privileges');
+    }
+    throw new Error(`Failed to fetch MCP clients: ${response.status} ${response.statusText}`);
+  }
+
+  const data = (await response.json()) as { data: MCPClient[] };
+
+  // The supervisor endpoint returns data in { data: [...] } format
+  if (data.data && Array.isArray(data.data)) {
+    const client = data.data.find((c) => c.id === id);
+    return client || null;
+  }
+
+  return null;
+}

--- a/experimental/pulsemcp-cms-admin/shared/src/pulsemcp-admin-client/lib/get-mcp-server-by-id.ts
+++ b/experimental/pulsemcp-cms-admin/shared/src/pulsemcp-admin-client/lib/get-mcp-server-by-id.ts
@@ -1,0 +1,39 @@
+import type { MCPServer } from '../../types.js';
+
+export async function getMCPServerById(
+  apiKey: string,
+  baseUrl: string,
+  id: number
+): Promise<MCPServer | null> {
+  // The API doesn't have a direct endpoint to get MCP server by ID,
+  // so we need to fetch all servers and find the one with matching ID
+  const url = new URL('/supervisor/mcp_servers', baseUrl);
+
+  const response = await fetch(url.toString(), {
+    method: 'GET',
+    headers: {
+      'X-API-Key': apiKey,
+      Accept: 'application/json',
+    },
+  });
+
+  if (!response.ok) {
+    if (response.status === 401) {
+      throw new Error('Invalid API key');
+    }
+    if (response.status === 403) {
+      throw new Error('User lacks admin privileges');
+    }
+    throw new Error(`Failed to fetch MCP servers: ${response.status} ${response.statusText}`);
+  }
+
+  const data = (await response.json()) as { data: MCPServer[] };
+
+  // The supervisor endpoint returns data in { data: [...] } format
+  if (data.data && Array.isArray(data.data)) {
+    const server = data.data.find((s) => s.id === id);
+    return server || null;
+  }
+
+  return null;
+}

--- a/experimental/pulsemcp-cms-admin/shared/src/pulsemcp-admin-client/lib/update-post.ts
+++ b/experimental/pulsemcp-cms-admin/shared/src/pulsemcp-admin-client/lib/update-post.ts
@@ -30,8 +30,15 @@ export async function updatePost(
   if (params.description_tag !== undefined)
     formData.append('post[description_tag]', params.description_tag);
   if (params.last_updated !== undefined) formData.append('post[last_updated]', params.last_updated);
-  if (params.table_of_contents !== undefined)
-    formData.append('post[table_of_contents]', JSON.stringify(params.table_of_contents));
+  if (params.table_of_contents !== undefined) {
+    // If table_of_contents is already a string (HTML), send it as-is
+    // If it's an object/array, stringify it
+    const tocValue =
+      typeof params.table_of_contents === 'string'
+        ? params.table_of_contents
+        : JSON.stringify(params.table_of_contents);
+    formData.append('post[table_of_contents]', tocValue);
+  }
 
   // Handle arrays for featured servers/clients
   if (params.featured_mcp_server_ids !== undefined) {

--- a/experimental/pulsemcp-cms-admin/shared/src/pulsemcp-admin-client/lib/upload-image.ts
+++ b/experimental/pulsemcp-cms-admin/shared/src/pulsemcp-admin-client/lib/upload-image.ts
@@ -18,11 +18,9 @@ export async function uploadImage(
   // Add file to form data
   formData.append('file', blob, fileName);
 
-  // Add folder path that includes the post slug
+  // Add folder and filepath as documented in the API
   formData.append('folder', `newsletter/${postSlug}`);
-
-  // Add the full filepath
-  formData.append('filepath', `newsletter/${postSlug}/${fileName}`);
+  formData.append('filepath', fileName);
 
   const response = await fetch(url.toString(), {
     method: 'POST',

--- a/experimental/pulsemcp-cms-admin/shared/src/pulsemcp-admin-client/lib/upload-image.ts
+++ b/experimental/pulsemcp-cms-admin/shared/src/pulsemcp-admin-client/lib/upload-image.ts
@@ -19,7 +19,7 @@ export async function uploadImage(
   formData.append('file', blob, fileName);
 
   // Add folder and filepath as documented in the API
-  formData.append('folder', `newsletter/${postSlug}`);
+  formData.append('folder', `posts/${postSlug}`);
   formData.append('filepath', fileName);
 
   const response = await fetch(url.toString(), {

--- a/experimental/pulsemcp-cms-admin/shared/src/pulsemcp-admin-client/pulsemcp-admin-client.integration-mock.ts
+++ b/experimental/pulsemcp-cms-admin/shared/src/pulsemcp-admin-client/pulsemcp-admin-client.integration-mock.ts
@@ -220,5 +220,60 @@ export function createMockPulseMCPAdminClient(mockData: MockData): IPulseMCPAdmi
         description: 'A test MCP client',
       };
     },
+
+    async getAuthorById(id) {
+      // Find author in the mock data
+      const authors = mockData.authors || [
+        {
+          id: 1,
+          name: 'Test Author',
+          slug: 'test-author',
+          created_at: '2024-01-01T00:00:00Z',
+          updated_at: '2024-01-01T00:00:00Z',
+        },
+      ];
+
+      return authors.find((a) => a.id === id) || null;
+    },
+
+    async getMCPServerById(id) {
+      // Find server in mock data by ID
+      const servers = Object.values(mockData.mcpServersBySlug || {});
+      const found = servers.find((s) => s.id === id);
+
+      if (found) return found;
+
+      // Return default if ID matches
+      if (id === 1) {
+        return {
+          id: 1,
+          name: 'Test MCP Server',
+          slug: 'test-mcp-server',
+          description: 'A test MCP server',
+        };
+      }
+
+      return null;
+    },
+
+    async getMCPClientById(id) {
+      // Find client in mock data by ID
+      const clients = Object.values(mockData.mcpClientsBySlug || {});
+      const found = clients.find((c) => c.id === id);
+
+      if (found) return found;
+
+      // Return default if ID matches
+      if (id === 1) {
+        return {
+          id: 1,
+          name: 'Test MCP Client',
+          slug: 'test-mcp-client',
+          description: 'A test MCP client',
+        };
+      }
+
+      return null;
+    },
   };
 }

--- a/experimental/pulsemcp-cms-admin/shared/src/server.ts
+++ b/experimental/pulsemcp-cms-admin/shared/src/server.ts
@@ -33,9 +33,15 @@ export interface IPulseMCPAdminClient {
 
   getAuthorBySlug(slug: string): Promise<Author>;
 
+  getAuthorById(id: number): Promise<Author | null>;
+
   getMCPServerBySlug(slug: string): Promise<MCPServer>;
 
+  getMCPServerById(id: number): Promise<MCPServer | null>;
+
   getMCPClientBySlug(slug: string): Promise<MCPClient>;
+
+  getMCPClientById(id: number): Promise<MCPClient | null>;
 }
 
 // PulseMCP Admin API client implementation
@@ -88,6 +94,11 @@ export class PulseMCPAdminClient implements IPulseMCPAdminClient {
     return getAuthorBySlug(this.apiKey, this.baseUrl, slug);
   }
 
+  async getAuthorById(id: number): Promise<Author | null> {
+    const { getAuthorById } = await import('./pulsemcp-admin-client/lib/get-author-by-id.js');
+    return getAuthorById(this.apiKey, this.baseUrl, id);
+  }
+
   async getMCPServerBySlug(slug: string): Promise<MCPServer> {
     const { getMCPServerBySlug } = await import(
       './pulsemcp-admin-client/lib/get-mcp-server-by-slug.js'
@@ -95,11 +106,25 @@ export class PulseMCPAdminClient implements IPulseMCPAdminClient {
     return getMCPServerBySlug(this.apiKey, this.baseUrl, slug);
   }
 
+  async getMCPServerById(id: number): Promise<MCPServer | null> {
+    const { getMCPServerById } = await import(
+      './pulsemcp-admin-client/lib/get-mcp-server-by-id.js'
+    );
+    return getMCPServerById(this.apiKey, this.baseUrl, id);
+  }
+
   async getMCPClientBySlug(slug: string): Promise<MCPClient> {
     const { getMCPClientBySlug } = await import(
       './pulsemcp-admin-client/lib/get-mcp-client-by-slug.js'
     );
     return getMCPClientBySlug(this.apiKey, this.baseUrl, slug);
+  }
+
+  async getMCPClientById(id: number): Promise<MCPClient | null> {
+    const { getMCPClientById } = await import(
+      './pulsemcp-admin-client/lib/get-mcp-client-by-id.js'
+    );
+    return getMCPClientById(this.apiKey, this.baseUrl, id);
   }
 }
 

--- a/experimental/pulsemcp-cms-admin/shared/src/tools/get-authors.ts
+++ b/experimental/pulsemcp-cms-admin/shared/src/tools/get-authors.ts
@@ -16,36 +16,17 @@ const GetAuthorsSchema = z.object({
 export function getAuthors(_server: Server, clientFactory: ClientFactory) {
   return {
     name: 'get_authors',
-    description: `Retrieve a list of authors from the PulseMCP CMS who can create newsletter posts. This tool is essential for finding the correct author_slug to use when creating new posts with the draft_newsletter_post tool.
+    description: `Retrieve a list of authors from the PulseMCP CMS who can create newsletter posts. Returns formatted markdown with author details.
 
-Example response:
-{
-  "authors": [
-    {
-      "id": 1,
-      "name": "Sarah Chen",
-      "slug": "sarah-chen",
-      "bio": "Senior Developer Advocate specializing in AI integrations and MCP",
-      "avatar_url": "https://cdn.pulsemcp.com/authors/sarah-chen.jpg",
-      "created_at": "2023-06-15T08:00:00Z",
-      "updated_at": "2024-01-10T12:30:00Z"
-    },
-    {
-      "id": 2,
-      "name": "John Smith",
-      "slug": "john-smith",
-      "bio": "Technical Writer focused on developer documentation",
-      "avatar_url": "https://cdn.pulsemcp.com/authors/john-smith.jpg",
-      "created_at": "2023-07-20T10:00:00Z",
-      "updated_at": "2024-01-08T15:45:00Z"
-    }
-  ],
-  "pagination": {
-    "current_page": 1,
-    "total_pages": 3,
-    "total_count": 12
-  }
-}
+The response is formatted as markdown with:
+- Total count and pagination info
+- Author entries, each showing:
+  - Name (as section header)
+  - Slug (required for creating/updating posts)
+  - Bio (if available)
+  - Avatar image URL (if available)
+  - Created date
+
 
 Use cases:
 - Find available authors before creating a new newsletter post

--- a/experimental/pulsemcp-cms-admin/shared/src/tools/get-authors.ts
+++ b/experimental/pulsemcp-cms-admin/shared/src/tools/get-authors.ts
@@ -70,7 +70,7 @@ Use cases:
         } else {
           response.authors.forEach((author) => {
             content += `## ${author.name}\n`;
-            content += `**Slug:** ${author.slug}\n`;
+            content += `**Slug:** ${author.slug} (ID: ${author.id})\n`;
 
             if (author.bio) {
               content += `**Bio:** ${author.bio}\n`;

--- a/experimental/pulsemcp-cms-admin/shared/src/tools/get-newsletter-post.ts
+++ b/experimental/pulsemcp-cms-admin/shared/src/tools/get-newsletter-post.ts
@@ -85,7 +85,7 @@ Use cases:
         content += `**Status:** ${post.status} | **Category:** ${post.category}\n`;
 
         if (authorSlug && authorName) {
-          content += `**Author:** ${authorName} (${authorSlug})\n`;
+          content += `**Author:** ${authorName} (${authorSlug}, ID: ${post.author_id})\n`;
         }
 
         content += `**Created:** ${new Date(post.created_at).toLocaleDateString()}\n`;
@@ -135,36 +135,36 @@ Use cases:
         }
 
         if (post.featured_mcp_server_ids && post.featured_mcp_server_ids.length > 0) {
-          const serverSlugs: string[] = [];
+          const serverInfo: string[] = [];
           for (const serverId of post.featured_mcp_server_ids) {
             try {
               const server = await client.getMCPServerById(serverId);
               if (server) {
-                serverSlugs.push(server.slug);
+                serverInfo.push(`${server.slug} (ID: ${server.id})`);
               }
             } catch (error) {
               console.error(`Failed to fetch MCP server ${serverId}:`, error);
             }
           }
-          if (serverSlugs.length > 0) {
-            content += `- **Featured MCP Servers:** ${serverSlugs.join(', ')}\n`;
+          if (serverInfo.length > 0) {
+            content += `- **Featured MCP Servers:** ${serverInfo.join(', ')}\n`;
           }
         }
 
         if (post.featured_mcp_client_ids && post.featured_mcp_client_ids.length > 0) {
-          const clientSlugs: string[] = [];
+          const clientInfo: string[] = [];
           for (const clientId of post.featured_mcp_client_ids) {
             try {
               const mcpClient = await client.getMCPClientById(clientId);
               if (mcpClient) {
-                clientSlugs.push(mcpClient.slug);
+                clientInfo.push(`${mcpClient.slug} (ID: ${mcpClient.id})`);
               }
             } catch (error) {
               console.error(`Failed to fetch MCP client ${clientId}:`, error);
             }
           }
-          if (clientSlugs.length > 0) {
-            content += `- **Featured MCP Clients:** ${clientSlugs.join(', ')}\n`;
+          if (clientInfo.length > 0) {
+            content += `- **Featured MCP Clients:** ${clientInfo.join(', ')}\n`;
           }
         }
 

--- a/experimental/pulsemcp-cms-admin/shared/src/tools/get-newsletter-post.ts
+++ b/experimental/pulsemcp-cms-admin/shared/src/tools/get-newsletter-post.ts
@@ -14,31 +14,25 @@ const GetNewsletterPostSchema = z.object({
 export function getNewsletterPost(_server: Server, clientFactory: ClientFactory) {
   return {
     name: 'get_newsletter_post',
-    description: `Retrieve complete details for a specific newsletter post by its unique slug identifier. This tool returns the full HTML content, metadata, SEO fields, and all associated information for a single post.
+    description: `Retrieve complete details for a specific newsletter post by its unique slug identifier. Returns formatted markdown with all post metadata and content.
 
-Example response:
-{
-  "id": 42,
-  "title": "Introducing the Claude MCP Protocol",
-  "slug": "introducing-claude-mcp-protocol",
-  "body": "<h2>What is MCP?</h2><p>The Model Context Protocol (MCP) is a new standard...</p>",
-  "status": "live",
-  "category": "newsletter",
-  "author": {
-    "id": 1,
-    "name": "Sarah Chen"
-  },
-  "created_at": "2024-01-15T10:30:00Z",
-  "updated_at": "2024-01-16T14:20:00Z",
-  "short_description": "Learn about the new Model Context Protocol and how it enables powerful AI integrations",
-  "image_url": "https://cdn.pulsemcp.com/posts/mcp-intro/hero.png",
-  "preview_image_url": "https://cdn.pulsemcp.com/posts/mcp-intro/preview.png",
-  "share_image": "https://cdn.pulsemcp.com/posts/mcp-intro/social.png",
-  "title_tag": "Introducing Claude MCP Protocol - PulseMCP Newsletter",
-  "description_tag": "Discover the Model Context Protocol (MCP) and learn how to build powerful AI integrations with Claude",
-  "featured_mcp_server_ids": [12, 15, 18],
-  "featured_mcp_client_ids": [3, 7]
-}
+The response is formatted as markdown with sections for:
+- Post title and basic metadata (slug, status, category, author, dates)
+- Summary/short description
+- Full HTML content (body field) as raw HTML
+- Complete metadata including all URLs, SEO tags, and featured items
+- Table of contents (if available) as raw HTML
+
+All available fields from the post are included:
+- title, slug, status, category
+- author (id and name)
+- created_at, updated_at, last_updated
+- short_title, short_description
+- body (raw HTML content)
+- table_of_contents (raw HTML)
+- image_url, preview_image_url, share_image
+- title_tag, description_tag
+- featured_mcp_server_ids, featured_mcp_client_ids
 
 Status meanings:
 - draft: Unpublished posts that are being written or edited
@@ -74,11 +68,23 @@ Use cases:
         content += `**Status:** ${post.status} | **Category:** ${post.category}\n`;
 
         if (post.author) {
-          content += `**Author:** ${post.author.name}\n`;
+          content += `**Author:** ${post.author.name} (ID: ${post.author.id})\n`;
+        } else if (post.author_id) {
+          content += `**Author ID:** ${post.author_id}\n`;
         }
 
         content += `**Created:** ${new Date(post.created_at).toLocaleDateString()}\n`;
-        content += `**Updated:** ${new Date(post.updated_at).toLocaleDateString()}\n\n`;
+        content += `**Updated:** ${new Date(post.updated_at).toLocaleDateString()}\n`;
+
+        if (post.last_updated) {
+          content += `**Last Updated:** ${post.last_updated}\n`;
+        }
+
+        content += '\n';
+
+        if (post.short_title) {
+          content += `**Short Title:** ${post.short_title}\n`;
+        }
 
         if (post.short_description) {
           content += `**Summary:** ${post.short_description}\n\n`;
@@ -87,7 +93,11 @@ Use cases:
         if (post.body) {
           content += `## Content\n\n${post.body}\n\n`;
         } else {
-          content += `## Content\n\n*Content not available in preview*\n\n`;
+          content += `## Content\n\n*Content not available*\n\n`;
+        }
+
+        if (post.table_of_contents) {
+          content += `## Table of Contents\n\n${post.table_of_contents}\n\n`;
         }
 
         // Add metadata section

--- a/experimental/pulsemcp-cms-admin/shared/src/tools/get-newsletter-posts.ts
+++ b/experimental/pulsemcp-cms-admin/shared/src/tools/get-newsletter-posts.ts
@@ -93,7 +93,7 @@ Use cases:
             try {
               const author = await client.getAuthorById(post.author_id);
               if (author) {
-                content += `   Author: ${author.name} (${author.slug})\n`;
+                content += `   Author: ${author.name} (${author.slug}, ID: ${author.id})\n`;
               }
             } catch (error) {
               // Skip showing author if we can't fetch it

--- a/experimental/pulsemcp-cms-admin/shared/src/tools/get-newsletter-posts.ts
+++ b/experimental/pulsemcp-cms-admin/shared/src/tools/get-newsletter-posts.ts
@@ -84,18 +84,29 @@ Use cases:
 
         content += ':\n\n';
 
-        response.posts.forEach((post, index) => {
+        for (const [index, post] of response.posts.entries()) {
           content += `${index + 1}. **${post.title}** (${post.slug})\n`;
           content += `   Status: ${post.status} | Category: ${post.category}\n`;
-          if (post.author) {
-            content += `   Author: ${post.author.name}\n`;
+
+          // Fetch author details if we have an author_id
+          if (post.author_id) {
+            try {
+              const author = await client.getAuthorById(post.author_id);
+              if (author) {
+                content += `   Author: ${author.name} (${author.slug})\n`;
+              }
+            } catch (error) {
+              // Skip showing author if we can't fetch it
+              console.error(`Failed to fetch author ${post.author_id}:`, error);
+            }
           }
+
           content += `   Created: ${new Date(post.created_at).toLocaleDateString()}\n`;
           if (post.short_description) {
             content += `   ${post.short_description}\n`;
           }
           content += '\n';
-        });
+        }
 
         return {
           content: [

--- a/experimental/pulsemcp-cms-admin/shared/src/tools/get-newsletter-posts.ts
+++ b/experimental/pulsemcp-cms-admin/shared/src/tools/get-newsletter-posts.ts
@@ -22,36 +22,18 @@ const GetNewsletterPostsSchema = z.object({
 export function getNewsletterPosts(_server: Server, clientFactory: ClientFactory) {
   return {
     name: 'get_newsletter_posts',
-    description: `Retrieve a paginated list of newsletter posts from the PulseMCP CMS. This tool provides comprehensive search and filtering capabilities to find existing content, check post statuses, and browse the newsletter archive.
+    description: `Retrieve a paginated list of newsletter posts from the PulseMCP CMS. Returns formatted markdown with post summaries and metadata.
 
-Example response:
-{
-  "posts": [
-    {
-      "title": "Introducing the Claude MCP Protocol",
-      "slug": "introducing-claude-mcp-protocol",
-      "status": "live",
-      "category": "newsletter",
-      "author": { "name": "Sarah Chen" },
-      "created_at": "2024-01-15T10:30:00Z",
-      "short_description": "Learn about the new Model Context Protocol and how it enables powerful AI integrations"
-    },
-    {
-      "title": "Best Practices for MCP Server Development",
-      "slug": "mcp-server-best-practices",
-      "status": "draft",
-      "category": "newsletter",
-      "author": { "name": "John Smith" },
-      "created_at": "2024-01-12T14:20:00Z",
-      "short_description": "A comprehensive guide to building production-ready MCP servers"
-    }
-  ],
-  "pagination": {
-    "current_page": 1,
-    "total_pages": 5,
-    "total_count": 47
-  }
-}
+The response is formatted as markdown with:
+- Total count and pagination info
+- Numbered list of posts, each showing:
+  - Title and slug
+  - Status and category
+  - Author name (if available)
+  - Created date
+  - Short description (if available)
+
+Note: The list view does NOT include post body content. Use get_newsletter_post to retrieve full post details.
 
 Status meanings:
 - draft: Unpublished posts that are being written or edited

--- a/experimental/pulsemcp-cms-admin/shared/src/tools/update-newsletter-post.ts
+++ b/experimental/pulsemcp-cms-admin/shared/src/tools/update-newsletter-post.ts
@@ -17,7 +17,7 @@ const PARAM_DESCRIPTIONS = {
   short_description: 'Updated brief summary for listings and search results',
   description_tag: 'Updated SEO meta description (keep under 160 characters)',
   last_updated: 'ISO 8601 date string for content revision timestamp',
-  table_of_contents: 'Updated JSON structure for table of contents',
+  table_of_contents: 'Updated table of contents - can be HTML string or JSON structure',
   featured_mcp_server_slugs: 'Updated array of MCP server slugs to feature (replaces existing)',
   featured_mcp_client_slugs: 'Updated array of MCP client slugs to feature (replaces existing)',
 } as const;

--- a/experimental/pulsemcp-cms-admin/tests/functional/tools.test.ts
+++ b/experimental/pulsemcp-cms-admin/tests/functional/tools.test.ts
@@ -98,7 +98,7 @@ describe('Newsletter Tools', () => {
       expect(result.content[0].type).toBe('text');
       expect(result.content[0].text).toContain('Found 2 newsletter posts (page 1 of 2)');
       expect(result.content[0].text).toContain('First Post');
-      expect(result.content[0].text).toContain('John Doe (john-doe)'); // Now includes slug
+      expect(result.content[0].text).toContain('John Doe (john-doe, ID: 1)'); // Now includes slug and ID
       expect(result.content[0].text).toContain('A brief summary');
     });
 
@@ -178,10 +178,12 @@ describe('Newsletter Tools', () => {
       expect(result.content[0].type).toBe('text');
       const text = result.content[0].text;
       expect(text).toContain('# Test Post');
-      expect(text).toContain('Jane Smith (jane-smith)'); // Now includes slug
+      expect(text).toContain('Jane Smith (jane-smith, ID: 1)'); // Now includes slug and ID
       expect(text).toContain('This is the content');
       expect(text).toContain('- **Image URL:** https://example.com/image.jpg');
-      expect(text).toContain('- **Featured MCP Servers:** server-one, server-two, server-three'); // Now shows slugs
+      expect(text).toContain(
+        '- **Featured MCP Servers:** server-one (ID: 1), server-two (ID: 2), server-three (ID: 3)'
+      ); // Now shows slugs and IDs
     });
   });
 
@@ -427,7 +429,7 @@ describe('Newsletter Tools', () => {
       expect(result.content[0].type).toBe('text');
       expect(result.content[0].text).toContain('Found 2 authors (page 1 of 1)');
       expect(result.content[0].text).toContain('John Doe');
-      expect(result.content[0].text).toContain('**Slug:** john-doe');
+      expect(result.content[0].text).toContain('**Slug:** john-doe (ID: 1)');
       expect(result.content[0].text).toContain('A prolific writer');
       expect(result.content[0].text).toContain('Jane Smith');
     });

--- a/experimental/pulsemcp-cms-admin/tests/functional/tools.test.ts
+++ b/experimental/pulsemcp-cms-admin/tests/functional/tools.test.ts
@@ -53,7 +53,7 @@ describe('Newsletter Tools', () => {
 
       const mockClient: IPulseMCPAdminClient = {
         getPosts: vi.fn().mockResolvedValue({
-          posts: mockPosts,
+          posts: mockPosts.map((p) => ({ ...p, author: undefined })), // Remove author objects
           pagination: {
             current_page: 1,
             total_pages: 2,
@@ -66,8 +66,29 @@ describe('Newsletter Tools', () => {
         uploadImage: vi.fn(),
         getAuthors: vi.fn(),
         getAuthorBySlug: vi.fn(),
+        getAuthorById: vi.fn().mockImplementation((id: number) => {
+          const authors = [
+            {
+              id: 1,
+              slug: 'john-doe',
+              name: 'John Doe',
+              created_at: '2024-01-01T00:00:00Z',
+              updated_at: '2024-01-01T00:00:00Z',
+            },
+            {
+              id: 2,
+              slug: 'jane-smith',
+              name: 'Jane Smith',
+              created_at: '2024-01-01T00:00:00Z',
+              updated_at: '2024-01-01T00:00:00Z',
+            },
+          ];
+          return Promise.resolve(authors.find((a) => a.id === id) || null);
+        }),
         getMCPServerBySlug: vi.fn(),
+        getMCPServerById: vi.fn(),
         getMCPClientBySlug: vi.fn(),
+        getMCPClientById: vi.fn(),
       };
 
       const tool = getNewsletterPosts(mockServer, () => mockClient);
@@ -77,7 +98,7 @@ describe('Newsletter Tools', () => {
       expect(result.content[0].type).toBe('text');
       expect(result.content[0].text).toContain('Found 2 newsletter posts (page 1 of 2)');
       expect(result.content[0].text).toContain('First Post');
-      expect(result.content[0].text).toContain('John Doe');
+      expect(result.content[0].text).toContain('John Doe (john-doe)'); // Now includes slug
       expect(result.content[0].text).toContain('A brief summary');
     });
 
@@ -90,8 +111,11 @@ describe('Newsletter Tools', () => {
         uploadImage: vi.fn(),
         getAuthors: vi.fn(),
         getAuthorBySlug: vi.fn(),
+        getAuthorById: vi.fn(),
         getMCPServerBySlug: vi.fn(),
+        getMCPServerById: vi.fn(),
         getMCPClientBySlug: vi.fn(),
+        getMCPClientById: vi.fn(),
       };
 
       const tool = getNewsletterPosts(mockServer, () => mockClient);
@@ -114,7 +138,6 @@ describe('Newsletter Tools', () => {
         category: 'newsletter',
         created_at: '2024-01-15T00:00:00Z',
         updated_at: '2024-01-16T00:00:00Z',
-        author: { id: 1, name: 'Jane Smith' },
         short_description: 'Test summary',
         image_url: 'https://example.com/image.jpg',
         featured_mcp_server_ids: [1, 2, 3],
@@ -128,8 +151,24 @@ describe('Newsletter Tools', () => {
         uploadImage: vi.fn(),
         getAuthors: vi.fn(),
         getAuthorBySlug: vi.fn(),
+        getAuthorById: vi.fn().mockResolvedValue({
+          id: 1,
+          slug: 'jane-smith',
+          name: 'Jane Smith',
+          created_at: '2024-01-01T00:00:00Z',
+          updated_at: '2024-01-01T00:00:00Z',
+        }),
         getMCPServerBySlug: vi.fn(),
+        getMCPServerById: vi.fn().mockImplementation((id: number) => {
+          const servers = [
+            { id: 1, slug: 'server-one', name: 'Server One' },
+            { id: 2, slug: 'server-two', name: 'Server Two' },
+            { id: 3, slug: 'server-three', name: 'Server Three' },
+          ];
+          return Promise.resolve(servers.find((s) => s.id === id) || null);
+        }),
         getMCPClientBySlug: vi.fn(),
+        getMCPClientById: vi.fn(),
       };
 
       const tool = getNewsletterPost(mockServer, () => mockClient);
@@ -139,10 +178,10 @@ describe('Newsletter Tools', () => {
       expect(result.content[0].type).toBe('text');
       const text = result.content[0].text;
       expect(text).toContain('# Test Post');
-      expect(text).toContain('Jane Smith');
+      expect(text).toContain('Jane Smith (jane-smith)'); // Now includes slug
       expect(text).toContain('This is the content');
       expect(text).toContain('- **Image URL:** https://example.com/image.jpg');
-      expect(text).toContain('- **Featured MCP Servers:** 1, 2, 3');
+      expect(text).toContain('- **Featured MCP Servers:** server-one, server-two, server-three'); // Now shows slugs
     });
   });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5605,7 +5605,7 @@
     },
     "productionized/pulse-fetch/local": {
       "name": "@pulsemcp/pulse-fetch",
-      "version": "0.2.12",
+      "version": "0.2.13",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.36.3",
@@ -5639,6 +5639,7 @@
         "zod": "^3.24.1"
       },
       "devDependencies": {
+        "@types/jsdom": "^21.1.7",
         "@types/node": "^24.0.0",
         "typescript": "^5.8.3",
         "vitest": "^3.2.3"


### PR DESCRIPTION
## Summary

This PR implements significant improvements to the PulseMCP CMS Admin MCP server (v0.0.3):

1. **Breaking Change**: All tools now return slugs instead of IDs for better API consistency
2. **Enhancement**: Output now shows both slug and ID in format `slug-name (ID: 123)` for easier debugging
3. **Bug Fix**: Fixed double-escaping of table_of_contents HTML strings

## Changes in Detail

### 🔄 Breaking Change: Slug-based Returns
- `get_newsletter_post` now returns author slug instead of just author ID
- `get_newsletter_post` returns MCP server/client slugs instead of IDs
- `get_newsletter_posts` returns author slug with name
- Added new API client methods: `getAuthorById`, `getMCPServerById`, `getMCPClientById`

### ✨ Enhancement: Dual Slug/ID Display
- All tools now display resources in format: `slug-name (ID: 123)`
- Provides better debugging info while maintaining slug-based interface
- Applied to `get_newsletter_post`, `get_newsletter_posts`, and `get_authors` tools

### 🐛 Bug Fix: Table of Contents
- Fixed double-escaping issue where HTML strings were being JSON.stringify'd twice
- Now checks if table_of_contents is already a string before stringifying
- Applies to both create-post and update-post operations

### 📋 Also Includes (from v0.0.3)
- Fixed nested subfolder issue in image uploads
- Updated tool descriptions to accurately reflect markdown-formatted responses
- Fixed get_newsletter_post to include all available fields
- Fixed get_authors description to correctly note image_url field

## Test Results

- **Unit Tests**: ✅ All 10 tests passing
- **Manual Tests**: ✅ All 9 tests passing (commit: 9f81630)
- **CI**: ✅ All checks passing

## Checklist
- [x] Version bumped to 0.0.3
- [x] CHANGELOG.md updated with all changes
- [x] All tests passing (unit and manual)
- [x] Manual tests run on latest commit
- [x] Git tag created: `pulsemcp-cms-admin-mcp-server@0.0.3`
- [x] README.md updated with new version

🤖 Generated with [Claude Code](https://claude.ai/code)