### PR TITLE
feat: add FIRECRAWL_API_BASE_URL environment variable support

### DIFF
--- a/productionized/pulse-fetch/.env.example
+++ b/productionized/pulse-fetch/.env.example
@@ -5,6 +5,11 @@
 # Get one at: https://www.firecrawl.dev/
 FIRECRAWL_API_KEY=your-firecrawl-api-key-here
 
+# Firecrawl API Base URL (optional)
+# Custom base URL for Firecrawl API (useful for self-hosted instances)
+# Defaults to: https://api.firecrawl.dev
+# FIRECRAWL_API_BASE_URL=https://api.firecrawl.dev
+
 # BrightData API Key (optional)  
 # Get one at: https://brightdata.com/ from the Web Unlocker product
 # Just provide the token - 'Bearer ' will be prepended automatically

--- a/productionized/pulse-fetch/shared/src/scraping-client/lib/firecrawl-scrape.ts
+++ b/productionized/pulse-fetch/shared/src/scraping-client/lib/firecrawl-scrape.ts
@@ -1,3 +1,20 @@
+// Validate and cache the base URL at module load time
+const getBaseUrl = (): string => {
+  const baseUrl = process.env.FIRECRAWL_API_BASE_URL || 'https://api.firecrawl.dev';
+  
+  // Validate baseUrl to prevent injection attacks
+  if (
+    baseUrl &&
+    (!/^https?:\/\/[^\\]+$/.test(baseUrl) || baseUrl.includes('..'))
+  ) {
+    throw new Error('Invalid FIRECRAWL_API_BASE_URL');
+  }
+  
+  return baseUrl;
+};
+
+const FIRECRAWL_BASE_URL = getBaseUrl();
+
 export async function scrapeWithFirecrawl(
   apiKey: string,
   url: string,
@@ -13,8 +30,7 @@ export async function scrapeWithFirecrawl(
   error?: string;
 }> {
   try {
-    const baseUrl = process.env.FIRECRAWL_API_BASE_URL || 'https://api.firecrawl.dev';
-    const response = await fetch(`${baseUrl}/v1/scrape`, {
+    const response = await fetch(`${FIRECRAWL_BASE_URL}/v1/scrape`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',

--- a/productionized/pulse-fetch/shared/src/scraping-client/lib/firecrawl-scrape.ts
+++ b/productionized/pulse-fetch/shared/src/scraping-client/lib/firecrawl-scrape.ts
@@ -13,7 +13,8 @@ export async function scrapeWithFirecrawl(
   error?: string;
 }> {
   try {
-    const response = await fetch('https://api.firecrawl.dev/v1/scrape', {
+    const baseUrl = process.env.FIRECRAWL_API_BASE_URL || 'https://api.firecrawl.dev';
+    const response = await fetch(`${baseUrl}/v1/scrape`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',


### PR DESCRIPTION
## Description

This PR adds support for configuring a custom Firecrawl API base URL via the `FIRECRAWL_API_BASE_URL` environment variable.

## Motivation

Currently, the Firecrawl API URL is hardcoded to `https://api.firecrawl.dev/v1/scrape`. This prevents users from:
- Using self-hosted Firecrawl instances
- Routing requests through custom proxy endpoints
- Testing against development/staging environments

## Changes

1. **Modified `firecrawl-scrape.ts`**: Updated the `scrapeWithFirecrawl` function to read the base URL from `process.env.FIRECRAWL_API_BASE_URL`, defaulting to `https://api.firecrawl.dev` when not set.

2. **Updated `.env.example`**: Added documentation for the new `FIRECRAWL_API_BASE_URL` environment variable.

## Usage

Users can now set a custom Firecrawl API base URL:

```bash
# .env
FIRECRAWL_API_BASE_URL=https://my-custom-firecrawl.example.com
```

If not set, the default (`https://api.firecrawl.dev`) is used, maintaining backward compatibility.

## Testing

- ✅ Backward compatible (defaults to original URL)
- ✅ Allows custom URL configuration
- ✅ No breaking changes to existing functionality