### PR TITLE
feat: Add wait-for-CI skill for blocking CI status checks

### DIFF
--- a/.claude/skills/wait-for-CI/SKILL.md
+++ b/.claude/skills/wait-for-CI/SKILL.md
@@ -1,4 +1,9 @@
-# Wait for CI Skill
+---
+name: wait-for-CI
+description: Block until CI passes or fails on the current PR
+---
+
+# Wait for CI
 
 This skill blocks until CI either passes or fails on the current PR using a single blocking command.
 


### PR DESCRIPTION
## Summary
- Adds a new Claude skill (`.claude/skills/wait-for-CI.md`) that provides structured instructions for waiting on CI to complete

## What the skill does
1. Detects when CI starts (fails if not within 1 minute)
2. Polls every 15 seconds until CI passes (all green) or fails (first failure detected)
3. Reports clear status on completion with details about which checks passed/failed

## Test plan
- [ ] Verify the skill file is properly loaded by Claude Code
- [ ] Test with a PR that has CI configured to ensure proper detection and waiting
- [ ] Verify failure cases report useful information

🤖 Generated with [Claude Code](https://claude.com/claude-code)