### PR TITLE
feat: add BigQuery MCP server config and PATH_TO_DEPLOY tracking

### DIFF
--- a/PATH_TO_DEPLOY.md
+++ b/PATH_TO_DEPLOY.md
@@ -1,0 +1,6 @@
+# Path to Deploy
+
+Things to resolve before deploying this app:
+
+- Figure out secrets management
+- Remove hardcoded system filepaths in MCP server configs (e.g. bigquery)

--- a/mcp-json-profiles/.mcp.base.json
+++ b/mcp-json-profiles/.mcp.base.json
@@ -3,6 +3,24 @@
     "ref": {
       "type": "http",
       "url": "https://api.ref.tools/mcp?apiKey={{REF_API_KEY}}"
+    },
+    "bigquery": {
+      "type": "stdio",
+      "command": "/Users/admin/.local/bin/uv",
+      "args": [
+        "--directory",
+        "/Users/admin/github-projects/mcp-server-bigquery",
+        "run",
+        "mcp-server-bigquery",
+        "--project",
+        "pulse-443819",
+        "--location",
+        "us-west1",
+        "--dataset",
+        "pulse_warehouse",
+        "--key-file",
+        "/Users/admin/.secrets/bq-service-account.json"
+      ]
     }
   }
 }


### PR DESCRIPTION
## Summary
- Add BigQuery MCP server configuration to `.mcp.base.json` for local development
- Create `PATH_TO_DEPLOY.md` to track deployment blockers including secrets management and hardcoded paths

**Note**: The BigQuery config intentionally uses hardcoded local paths for development purposes. The PATH_TO_DEPLOY.md file tracks this as a known blocker for production deployment.

## Test plan
- [x] Verify MCP server config JSON is valid (CI passed)
- [x] Confirm BigQuery config follows the expected format

🤖 Generated with [Claude Code](https://claude.com/claude-code)