### PR TITLE
docs: streamline PR workflow - review before CI wait

### DIFF
--- a/.claude/commands/pr.md
+++ b/.claude/commands/pr.md
@@ -14,8 +14,10 @@ Follow this checklist when executing this:
 - [ ] Run pre-commit checklist (see below)
 - [ ] Push it
 - [ ] Open a PR
-- [ ] Wait for the PR to successfully pass CI
-- [ ] If it fails CI, investigate the failure, fix it. Repeat until CI is passing
+- [ ] Perform self-code review of the PR diff
+- [ ] Action any issues found during review
+- [ ] Wait for CI to complete using the `wait-for-CI` skill
+- [ ] If CI fails, investigate the failure, fix it. Repeat until CI is passing
 - [ ] Think about what you learned during this PR creation process. Add any useful insights to the "Claude Learnings" section in the appropriate CLAUDE.md file (could be root or subdirectory)
 - [ ] Surface the PR link back to the user
 
@@ -78,6 +80,19 @@ git diff --cached
 
 Immediately check if there are any merge conflicts. Resolve them by following [merge_conflicts.md](./merge_conflicts.md).
 
+#### Self-Code Review
+
+Before waiting for CI, perform a self-code review of your PR diff:
+
+1. Review the diff on GitHub or via `gh pr diff`
+2. Look for:
+   - Logic errors or bugs
+   - Missing edge cases
+   - Code style issues
+   - Unnecessary changes or debug code
+   - Security concerns
+3. Fix any issues found and push the fixes
+
 #### CI Monitoring
 
-After creating the PR with no merge conflicts, monitor CI status and fix any failures by following [ensure_ci_success.md](./ensure_ci_success.md).
+After completing your self-review (and actioning any issues), monitor CI status and fix any failures by following [ensure_ci_success.md](./ensure_ci_success.md).


### PR DESCRIPTION
## Summary

- Reorders the PR workflow checklist to perform self-code review immediately after opening a PR, before waiting for CI
- Adds a new "Self-Code Review" section to the Post-PR open checklist with detailed guidance
- Updates CI monitoring section to clarify it happens after review is complete

## Motivation

The previous workflow had agents wait for CI to pass before doing any review work. This was inefficient because:

1. CI can take several minutes to complete
2. Issues found during review would need to be fixed anyway
3. Fixing review issues would restart CI, negating the wait

The new workflow allows review work to happen in parallel with CI running, and consolidates any fixes before the final CI check.

## New Workflow Order

1. Open PR
2. **Perform self-code review of the PR diff** (new step)
3. **Action any issues found during review** (new step)
4. Wait for CI to complete using the `wait-for-CI` skill
5. Fix any CI failures and iterate to green

## Files Changed

- `.claude/commands/pr.md` - Updated main checklist and added Self-Code Review section

## Files Reviewed (No Changes Needed)

- `.claude/commands/ensure_ci_success.md` - Already correctly scoped to the CI iteration phase
- `.claude/commands/publish_and_pr.md` - References pr.md, so inherits the updated workflow
- `.claude/skills/wait-for-CI/SKILL.md` - Utility skill, unchanged
- `CLAUDE.md` - Line about "ensure CI passes before considering a PR complete" refers to end state, not ordering

## Test plan

- [ ] Verify the updated checklist in pr.md reads logically
- [ ] Confirm the Self-Code Review section provides useful guidance
- [ ] Test that agents following these instructions perform review before CI wait

🤖 Generated with [Claude Code](https://claude.com/claude-code)