### PR TITLE
docs: update MCP server READMEs with npm package installation instructions

### DIFF
--- a/experimental/claude-code-agent/CHANGELOG.md
+++ b/experimental/claude-code-agent/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the Claude Code Agent MCP Server will be documented in th
 
 ## [Unreleased]
 
+### Changed
+
+- Updated README Claude Desktop section to use npx installation (package is now published)
+
 ## [0.0.6] - 2025-10-13
 
 **CRITICAL FIX: Publishing Script**

--- a/experimental/claude-code-agent/README.md
+++ b/experimental/claude-code-agent/README.md
@@ -77,16 +77,26 @@ This approach scales to hundreds of trusted servers without any tool overload, a
 
 ### Claude Desktop
 
-#### Using NPM (when published)
+Make sure you have your servers.md and servers.json configuration files ready.
 
-Add this to your `claude_desktop_config.json`:
+Then proceed to the setup instructions below. If this is your first time using MCP Servers, you'll want to make sure you have the [Claude Desktop application](https://claude.ai/download) and follow the [official MCP setup instructions](https://modelcontextprotocol.io/quickstart/user).
+
+#### Manual Setup
+
+You're going to need Node working on your machine so you can run `npx` commands in your terminal. If you don't have Node, you can install it from [nodejs.org](https://nodejs.org/en/download).
+
+macOS: `~/Library/Application Support/Claude/claude_desktop_config.json`
+
+Windows: `%APPDATA%\Claude\claude_desktop_config.json`
+
+Modify your `claude_desktop_config.json` file to add the following:
 
 ```json
 {
   "mcpServers": {
     "claude-code-agent": {
       "command": "npx",
-      "args": ["claude-code-agent-mcp-server"],
+      "args": ["-y", "claude-code-agent-mcp-server"],
       "env": {
         "TRUSTED_SERVERS_PATH": "/path/to/your/servers.md",
         "SERVER_CONFIGS_PATH": "/path/to/your/servers.json"
@@ -96,24 +106,7 @@ Add this to your `claude_desktop_config.json`:
 }
 ```
 
-#### Using Local Build
-
-For development or before the package is published:
-
-```json
-{
-  "mcpServers": {
-    "claude-code-agent": {
-      "command": "node",
-      "args": ["/path/to/claude-code-agent/local/build/index.js"],
-      "env": {
-        "TRUSTED_SERVERS_PATH": "/path/to/your/servers.md",
-        "SERVER_CONFIGS_PATH": "/path/to/your/servers.json"
-      }
-    }
-  }
-}
-```
+Restart Claude Desktop and you should be ready to go!
 
 ## Development
 

--- a/experimental/good-eggs/CHANGELOG.md
+++ b/experimental/good-eggs/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Improved README setup section for better consistency with other MCP servers
+
 ## [0.1.7] - 2026-01-18
 
 ### Fixed

--- a/experimental/good-eggs/README.md
+++ b/experimental/good-eggs/README.md
@@ -27,23 +27,14 @@ MCP server for Good Eggs grocery shopping automation using Playwright. Search fo
 | `add_favorite`                 | Add a product to your favorites                      |
 | `remove_favorite`              | Remove a product from your favorites                 |
 
-## Quick Start
+## Setup
 
 ### Prerequisites
 
 - Node.js 18+
 - A Good Eggs account (create one at [goodeggs.com](https://www.goodeggs.com))
 
-### Installation
-
-```bash
-npm install
-npm run build
-```
-
-### Configuration
-
-Set the following environment variables:
+### Environment Variables
 
 | Variable             | Required | Description                     | Default |
 | -------------------- | -------- | ------------------------------- | ------- |
@@ -52,13 +43,21 @@ Set the following environment variables:
 | `HEADLESS`           | No       | Run browser in headless mode    | `true`  |
 | `TIMEOUT`            | No       | Browser operation timeout (ms)  | `30000` |
 
-### Claude Desktop Configuration
+### Claude Desktop
 
-Add to your `claude_desktop_config.json`:
+Make sure you have your Good Eggs account credentials ready.
 
-**macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`
+Then proceed to the setup instructions below. If this is your first time using MCP Servers, you'll want to make sure you have the [Claude Desktop application](https://claude.ai/download) and follow the [official MCP setup instructions](https://modelcontextprotocol.io/quickstart/user).
 
-**Windows**: `%APPDATA%\Claude\claude_desktop_config.json`
+#### Manual Setup
+
+You're going to need Node working on your machine so you can run `npx` commands in your terminal. If you don't have Node, you can install it from [nodejs.org](https://nodejs.org/en/download).
+
+macOS: `~/Library/Application Support/Claude/claude_desktop_config.json`
+
+Windows: `%APPDATA%\Claude\claude_desktop_config.json`
+
+Modify your `claude_desktop_config.json` file to add the following:
 
 ```json
 {
@@ -75,7 +74,7 @@ Add to your `claude_desktop_config.json`:
 }
 ```
 
-Restart Claude Desktop to connect.
+Restart Claude Desktop and you should be ready to go!
 
 ## Usage Examples
 

--- a/experimental/proctor/CHANGELOG.md
+++ b/experimental/proctor/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Updated README to use npx installation method instead of local build instructions
+
 ## [0.1.0] - 2025-01-18
 
 ### Added

--- a/experimental/proctor/README.md
+++ b/experimental/proctor/README.md
@@ -175,9 +175,59 @@ There are 2 active machines:
 
 # Setup
 
-## Cheatsheet
+## Claude Desktop
 
-Quick setup:
+Make sure you have your Proctor API key ready.
+
+Then proceed to the setup instructions below. If this is your first time using MCP Servers, you'll want to make sure you have the [Claude Desktop application](https://claude.ai/download) and follow the [official MCP setup instructions](https://modelcontextprotocol.io/quickstart/user).
+
+### Manual Setup
+
+You're going to need Node working on your machine so you can run `npx` commands in your terminal. If you don't have Node, you can install it from [nodejs.org](https://nodejs.org/en/download).
+
+macOS: `~/Library/Application Support/Claude/claude_desktop_config.json`
+
+Windows: `%APPDATA%\Claude\claude_desktop_config.json`
+
+Modify your `claude_desktop_config.json` file to add the following:
+
+```json
+{
+  "mcpServers": {
+    "proctor": {
+      "command": "npx",
+      "args": ["-y", "proctor-mcp-server"],
+      "env": {
+        "PROCTOR_API_KEY": "your-api-key-here",
+        "TOOL_GROUPS": "exams,machines"
+      }
+    }
+  }
+}
+```
+
+Restart Claude Desktop and you should be ready to go!
+
+For read-only access:
+
+```json
+{
+  "mcpServers": {
+    "proctor-readonly": {
+      "command": "npx",
+      "args": ["-y", "proctor-mcp-server"],
+      "env": {
+        "PROCTOR_API_KEY": "your-api-key-here",
+        "TOOL_GROUPS": "exams_readonly,machines_readonly"
+      }
+    }
+  }
+}
+```
+
+## Development
+
+### Quick Setup
 
 ```bash
 # Install dependencies
@@ -191,55 +241,6 @@ export PROCTOR_API_KEY="your-api-key-here"
 
 # Run the server
 cd local && npm start
-```
-
-## Claude Desktop
-
-Add to your Claude Desktop configuration:
-
-### macOS: `~/Library/Application Support/Claude/claude_desktop_config.json`
-
-### Windows: `%APPDATA%\Claude\claude_desktop_config.json`
-
-```json
-{
-  "mcpServers": {
-    "proctor": {
-      "command": "node",
-      "args": ["/path/to/proctor/local/build/index.js"],
-      "env": {
-        "PROCTOR_API_KEY": "your-api-key-here",
-        "TOOL_GROUPS": "exams,machines"
-      }
-    }
-  }
-}
-```
-
-For read-only access:
-
-```json
-{
-  "mcpServers": {
-    "proctor-readonly": {
-      "command": "node",
-      "args": ["/path/to/proctor/local/build/index.js"],
-      "env": {
-        "PROCTOR_API_KEY": "your-api-key-here",
-        "TOOL_GROUPS": "exams_readonly,machines_readonly"
-      }
-    }
-  }
-}
-```
-
-### Manual Setup
-
-If you prefer to run the server manually:
-
-```bash
-cd /path/to/proctor/local
-PROCTOR_API_KEY="your-api-key-here" node build/index.js
 ```
 
 ## License

--- a/experimental/slack/CHANGELOG.md
+++ b/experimental/slack/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Renamed package from `@pulsemcp/slack-mcp-server` to `slack-workspace-mcp-server`
+- Improved README setup section for better consistency with other MCP servers (added `-y` flag to npx)
 
 ## [0.0.1] - 2026-01-02
 

--- a/experimental/slack/README.md
+++ b/experimental/slack/README.md
@@ -12,31 +12,19 @@ A Model Context Protocol (MCP) server for integrating with Slack workspaces. Thi
 - **Update Messages** - Edit previously posted messages
 - **React to Messages** - Add emoji reactions to messages
 
-## Installation
+## Setup
 
-```bash
-npm install slack-workspace-mcp-server
-```
+### Prerequisites
 
-Or run directly with npx:
+- A Slack workspace with admin permissions to create apps
+- A Slack Bot Token (see instructions below)
 
-```bash
-npx slack-workspace-mcp-server
-```
+### Environment Variables
 
-## Configuration
-
-### Required Environment Variables
-
-| Variable          | Description                | Example        |
-| ----------------- | -------------------------- | -------------- |
-| `SLACK_BOT_TOKEN` | Slack Bot User OAuth Token | `xoxb-1234...` |
-
-### Optional Environment Variables
-
-| Variable             | Description                         | Default     |
-| -------------------- | ----------------------------------- | ----------- |
-| `ENABLED_TOOLGROUPS` | Comma-separated list of tool groups | All enabled |
+| Variable             | Required | Description                         | Default     |
+| -------------------- | -------- | ----------------------------------- | ----------- |
+| `SLACK_BOT_TOKEN`    | Yes      | Slack Bot User OAuth Token          | -           |
+| `ENABLED_TOOLGROUPS` | No       | Comma-separated list of tool groups | All enabled |
 
 ### Getting a Bot Token
 
@@ -53,16 +41,28 @@ npx slack-workspace-mcp-server
 5. Install the app to your workspace
 6. Copy the **Bot User OAuth Token** (starts with `xoxb-`)
 
-### MCP Client Configuration
+### Claude Desktop
 
-For Claude Desktop, add to your configuration:
+Make sure you have your Slack Bot Token ready.
+
+Then proceed to the setup instructions below. If this is your first time using MCP Servers, you'll want to make sure you have the [Claude Desktop application](https://claude.ai/download) and follow the [official MCP setup instructions](https://modelcontextprotocol.io/quickstart/user).
+
+#### Manual Setup
+
+You're going to need Node working on your machine so you can run `npx` commands in your terminal. If you don't have Node, you can install it from [nodejs.org](https://nodejs.org/en/download).
+
+macOS: `~/Library/Application Support/Claude/claude_desktop_config.json`
+
+Windows: `%APPDATA%\Claude\claude_desktop_config.json`
+
+Modify your `claude_desktop_config.json` file to add the following:
 
 ```json
 {
   "mcpServers": {
     "slack": {
       "command": "npx",
-      "args": ["slack-workspace-mcp-server"],
+      "args": ["-y", "slack-workspace-mcp-server"],
       "env": {
         "SLACK_BOT_TOKEN": "xoxb-your-token-here"
       }
@@ -70,6 +70,8 @@ For Claude Desktop, add to your configuration:
   }
 }
 ```
+
+Restart Claude Desktop and you should be ready to go!
 
 ## Available Tools
 


### PR DESCRIPTION
## Summary

- Updated proctor-mcp-server README to use `npx -y proctor-mcp-server` instead of local build instructions
- Reorganized good-eggs-mcp-server README setup section for consistency with other servers  
- Updated claude-code-agent-mcp-server README to remove "(when published)" text since the package is now published
- Added `-y` flag to slack-workspace-mcp-server npx command for consistency

All published MCP servers now consistently show npm package installation as the primary setup method for Claude Desktop users.

## Test plan

- [ ] Verified all updated READMEs have correct npm package names matching package.json
- [ ] Verified npx commands follow consistent format: `npx -y <package-name>`
- [ ] Verified CHANGELOGs updated with documentation changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)