### PR TITLE
docs(pulsemcp-cms-admin): simplify Available Groups table in README

### DIFF
--- a/experimental/pulsemcp-cms-admin/CHANGELOG.md
+++ b/experimental/pulsemcp-cms-admin/CHANGELOG.md
@@ -10,7 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Simplified README "Available Groups" table to show only base tool groups instead of listing both base and `_readonly` variants separately
   - The `_readonly` variants are still supported but are now explained conceptually rather than listed as separate rows
-  - This matches the formatting style used in the proctor MCP server README
+  - Reduces table from 16 rows to 8 for better readability
 
 ## [0.6.2] - 2026-01-19
 

--- a/experimental/pulsemcp-cms-admin/README.md
+++ b/experimental/pulsemcp-cms-admin/README.md
@@ -89,7 +89,7 @@ This server organizes tools into groups that can be selectively enabled or disab
 | `newsletter`        | 6     | Full newsletter management (read + write) |
 | `server_queue`      | 5     | Full MCP implementation queue (read + write) |
 | `official_queue`    | 7     | Full official mirror queue (read + write) |
-| `unofficial_mirrors`| 5     | Full unofficial mirrors CRUD (read + write) |
+| `unofficial_mirrors` | 5     | Full unofficial mirrors CRUD (read + write) |
 | `official_mirrors`  | 2     | Official mirrors REST API (read-only)    |
 | `tenants`           | 2     | Tenants REST API (read-only)             |
 | `mcp_jsons`         | 5     | Full MCP JSON configurations (read + write) |


### PR DESCRIPTION
## Summary

- Simplifies the README "Available Groups" table by showing only base tool groups instead of listing both base and `_readonly` variants separately
- The `_readonly` variants are still supported but are now explained conceptually rather than as separate rows
- This matches the formatting style used in the proctor MCP server README

## Changes

- Updated `experimental/pulsemcp-cms-admin/README.md` to simplify the Available Groups table
- Updated `experimental/pulsemcp-cms-admin/CHANGELOG.md` with the change

## Test plan

- [ ] Verify README renders correctly on GitHub
- [ ] Confirm the table is easier to read and understand

🤖 Generated with [Claude Code](https://claude.com/claude-code)