### PR TITLE
docs(pulse-subregistry): clarify SHOW_ADMIN_TOOLS default is false

### DIFF
--- a/productionized/pulse-subregistry/CHANGELOG.md
+++ b/productionized/pulse-subregistry/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Documented default value for `SHOW_ADMIN_TOOLS` environment variable as `false` in README
+
 ## [0.0.2] - 2026-01-25
 
 ### Added

--- a/productionized/pulse-subregistry/README.md
+++ b/productionized/pulse-subregistry/README.md
@@ -121,7 +121,7 @@ Here are more servers...
 | -------------------------------- | ------------------------------------------------------ | -------- | ------- |
 | `PULSEMCP_SUBREGISTRY_API_KEY`   | Your PulseMCP API key                                  | Yes      | N/A     |
 | `PULSEMCP_SUBREGISTRY_TENANT_ID` | Your tenant identifier (for multi-tenant use)          | No       | N/A     |
-| `SHOW_ADMIN_TOOLS`               | Set to `true` to enable admin tools (switch_tenant_id) | No       | N/A     |
+| `SHOW_ADMIN_TOOLS`               | Set to `true` to enable admin tools (switch_tenant_id) | No       | `false` |
 
 ## Claude Desktop
 


### PR DESCRIPTION
## Summary
- Updated README to show `false` as the default value for `SHOW_ADMIN_TOOLS` environment variable instead of "N/A"
- The code already defaults to `false` when the env var is unset (via `process.env.SHOW_ADMIN_TOOLS === 'true'` check)
- This documentation update clarifies the actual behavior for users

## Test plan
- [x] Verify documentation change is accurate by reviewing code in `local/src/index.ts`
- [x] Confirmed the variable is not required and defaults to `false`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)