### PR TITLE
fix(s3): simplify CI setup to match other servers

### DIFF
--- a/experimental/s3/package.json
+++ b/experimental/s3/package.json
@@ -16,7 +16,7 @@
     "build:test": "node ../../scripts/build-mcp-server.js && cd ../../libs/test-mcp-client && npm run build",
     "clean": "find . -name '*.js' -not -path './node_modules/*' -not -path './*/node_modules/*' -not -path './local/build/*' -not -path './shared/build/*' -not -path './*/build/*' -delete && find . -name '*.js.map' -not -path './node_modules/*' -not -path './*/node_modules/*' -not -path './local/build/*' -not -path './shared/build/*' -not -path './*/build/*' -delete",
     "dev": "cd local && npm run dev",
-    "test": "node scripts/run-vitest.js run",
+    "test": "node scripts/run-vitest.js",
     "test:ui": "node scripts/run-vitest.js --ui",
     "test:run": "node scripts/run-vitest.js run",
     "test:integration": "npm run build:test && node scripts/run-vitest.js run -c vitest.config.integration.ts && npm run clean",

--- a/experimental/s3/scripts/run-vitest.js
+++ b/experimental/s3/scripts/run-vitest.js
@@ -1,35 +1,14 @@
 #!/usr/bin/env node
 /**
- * Wrapper script to run vitest with proper ES module support.
- * Handles npm workspace hoisting by checking multiple node_modules locations.
+ * Wrapper script to run vitest with proper ES module support
  */
 
 import { fileURLToPath } from 'url';
 import { dirname, join } from 'path';
-import { existsSync } from 'fs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
-// Possible vitest locations (in order of preference):
-// 1. Local node_modules (experimental/s3/node_modules)
-// 2. Monorepo root node_modules (../../node_modules from experimental/s3)
-const vitestPaths = [
-  join(__dirname, '../node_modules/vitest/dist/cli.js'),
-  join(__dirname, '../../../node_modules/vitest/dist/cli.js'),
-];
-
-let imported = false;
-for (const vitestPath of vitestPaths) {
-  if (existsSync(vitestPath)) {
-    await import(vitestPath);
-    imported = true;
-    break;
-  }
-}
-
-if (!imported) {
-  console.error('Error: Could not find vitest in any node_modules location.');
-  console.error('Searched paths:', vitestPaths);
-  process.exit(1);
-}
+// Import and run vitest CLI
+const vitestCliPath = join(__dirname, '../node_modules/vitest/dist/cli.js');
+await import(vitestCliPath);


### PR DESCRIPTION
## Summary

Simplifies the S3 MCP server's CI/vitest setup to match the pattern used by other servers like DynamoDB.

## Changes

- Simplified `run-vitest.js` to use the simple direct import pattern (matching DynamoDB)
- Updated `test` script to not pass "run" argument (matching DynamoDB pattern)

## Why

The S3 server had a more complex vitest runner with fallback logic that wasn't necessary. This brings it in line with how other MCP servers in the repo are configured.

## Test plan

- [x] Tests pass locally with `npm test`
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)