### PR TITLE
Publish vercel-platform-mcp-server@0.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ These are high-quality servers that we may discontinue if the official provider 
 | [slack](./experimental/slack/)                           | Slack workspace messaging and collaboration integration            | 0.0.1        | Not Started   | Teams using Slack for team communication                    | Requires Slack Bot Token; NOT officially affiliated with Slack                                                        |
 | [ssh](./experimental/ssh/)                               | SSH remote server management with agent authentication             | 0.1.2        | Not Started   | Developers needing SSH access to remote servers             | Supports SSH agent for passphrase-protected keys                                                                      |
 | [twist](./experimental/twist/)                           | Twist team messaging and collaboration platform integration        | 0.2.0        | Not Started   | Teams using Twist for asynchronous communication            | Requires Twist API bearer token and workspace ID                                                                      |
+| [vercel](./experimental/vercel/)                         | Vercel deployment management and runtime log retrieval             | 0.1.0        | Not Started   | Developers using Vercel for deployment and hosting          | Requires Vercel API token; Published as `vercel-platform-mcp-server`; NOT officially affiliated with Vercel           |
 
 ## Contributing
 

--- a/experimental/vercel/CHANGELOG.md
+++ b/experimental/vercel/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.0] - 2026-02-10
+
 ### Added
 
 - Initial Vercel MCP server implementation

--- a/experimental/vercel/MANUAL_TESTING.md
+++ b/experimental/vercel/MANUAL_TESTING.md
@@ -14,7 +14,7 @@ npm run test:manual
 
 ## Latest Test Results
 
-**Commit:** 5451b88
+**Commit:** 111e4f8
 **Date:** 2026-02-10
 **Test count:** 8 tests (3 SUCCESS, 5 WARNING - no deployments/projects on test account)
 

--- a/experimental/vercel/local/package.json
+++ b/experimental/vercel/local/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vercel-platform-mcp-server",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "description": "Local implementation of Vercel MCP server",
   "main": "build/index.js",
   "type": "module",

--- a/experimental/vercel/package-lock.json
+++ b/experimental/vercel/package-lock.json
@@ -31,7 +31,7 @@
     },
     "local": {
       "name": "vercel-platform-mcp-server",
-      "version": "0.0.0",
+      "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.19.1",


### PR DESCRIPTION
## Summary
- Version bump `vercel-platform-mcp-server` from 0.0.0 to 0.1.0 for initial npm publication
- Moves CHANGELOG entries from [Unreleased] to [0.1.0] section
- Adds vercel to the Experimental Servers table in root README
- Updates MANUAL_TESTING.md commit reference to the merged PR commit

This is a publish-only PR - no code changes. The server code was merged in PR #305.

## Test plan
- [x] No code changes - version bump, changelog, and README only
- [x] Git tag `vercel-platform-mcp-server@0.1.0` created
- [x] CI should pass all checks including verify-publications

🤖 Generated with [Claude Code](https://claude.com/claude-code)