### PR TITLE
Migrate CI workflows to self-hosted runner

### DIFF
--- a/.github/workflows/appsignal-ci.yml
+++ b/.github/workflows/appsignal-ci.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   functional-tests:
     name: AppSignal MCP Server Functional Tests
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
 
     defaults:
       run:
@@ -57,7 +57,7 @@ jobs:
 
   integration-tests:
     name: AppSignal MCP Server Integration Tests
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
 
     defaults:
       run:

--- a/.github/workflows/ci-build-test-checks.yml
+++ b/.github/workflows/ci-build-test-checks.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   ci-build-test-checks:
     name: CI Build & Test Checks Passed
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     permissions:
       checks: read
       pull-requests: read

--- a/.github/workflows/claude-code-agent-ci.yml
+++ b/.github/workflows/claude-code-agent-ci.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   functional-tests:
     name: Claude Code Agent MCP Server Functional Tests
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
 
     defaults:
       run:
@@ -54,7 +54,7 @@ jobs:
 
   integration-tests:
     name: Claude Code Agent MCP Server Integration Tests
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
 
     defaults:
       run:

--- a/.github/workflows/hatchbox-ci.yml
+++ b/.github/workflows/hatchbox-ci.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   functional-tests:
     name: Hatchbox MCP Server Functional Tests
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
 
     defaults:
       run:
@@ -59,7 +59,7 @@ jobs:
 
   integration-tests:
     name: Hatchbox MCP Server Integration Tests
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
 
     defaults:
       run:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,7 +25,7 @@ on:
 jobs:
   lint:
     name: Lint & Type Check
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/publish-mcp-servers.yml
+++ b/.github/workflows/publish-mcp-servers.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   wait-for-ci:
     name: Wait for CI
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - name: Wait for CI Build & Test Checks
         uses: actions/github-script@v7
@@ -68,7 +68,7 @@ jobs:
 
   detect-and-publish:
     needs: wait-for-ci
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     permissions:
       contents: write
       packages: write

--- a/.github/workflows/pulse-fetch-ci.yml
+++ b/.github/workflows/pulse-fetch-ci.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   functional-tests:
     name: Pulse Fetch MCP Server Functional Tests
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
 
     defaults:
       run:
@@ -57,7 +57,7 @@ jobs:
 
   integration-tests:
     name: Pulse Fetch MCP Server Integration Tests
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
 
     defaults:
       run:

--- a/.github/workflows/slack-ci.yml
+++ b/.github/workflows/slack-ci.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   functional-tests:
     name: Slack MCP Server Functional Tests
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
 
     defaults:
       run:
@@ -56,7 +56,7 @@ jobs:
 
   integration-tests:
     name: Slack MCP Server Integration Tests
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
 
     defaults:
       run:

--- a/.github/workflows/twist-ci.yml
+++ b/.github/workflows/twist-ci.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   functional-tests:
     name: Twist MCP Server Functional Tests
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
 
     defaults:
       run:
@@ -57,7 +57,7 @@ jobs:
 
   integration-tests:
     name: Twist MCP Server Integration Tests
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
 
     defaults:
       run:

--- a/.github/workflows/validate-publish-files.yml
+++ b/.github/workflows/validate-publish-files.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   validate-publish-files:
     name: Validate Publish Files
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/verify-mcp-server-publication.yml
+++ b/.github/workflows/verify-mcp-server-publication.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   verify-publications:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Summary
- Migrates all 11 GitHub Actions workflow files from `ubuntu-latest` to `self-hosted`
- Aligns mcp-servers CI infrastructure with the existing self-hosted Hetzner runner used by `pulsemcp/pulsemcp` and `pulsemcp/agents`
- No other workflow changes needed: Node.js setup via `actions/setup-node@v4` works on self-hosted runners, and there are no service containers or Ruby-specific concerns in this repo

## Changes
All 18 occurrences of `runs-on: ubuntu-latest` across 11 workflow files changed to `runs-on: self-hosted`:
- `appsignal-ci.yml` (2 jobs)
- `ci-build-test-checks.yml` (1 job)
- `claude-code-agent-ci.yml` (2 jobs)
- `hatchbox-ci.yml` (2 jobs)
- `lint.yml` (1 job)
- `publish-mcp-servers.yml` (2 jobs)
- `pulse-fetch-ci.yml` (2 jobs)
- `slack-ci.yml` (2 jobs)
- `twist-ci.yml` (2 jobs)
- `validate-publish-files.yml` (1 job)
- `verify-mcp-server-publication.yml` (1 job)

## Secrets Required
The `NPM_TOKEN` secret used by `publish-mcp-servers.yml` must be available to the self-hosted runner. If it's configured as a repository secret, it should work automatically. Please verify this secret is set in the repo settings.

## Test plan
- [ ] Verify all CI checks pass on this PR (lint, test, validate workflows)
- [ ] Confirm the self-hosted runner picks up the jobs successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)