### PR TITLE
fix(fetchpet): fix login timeout from waitForURL hanging on third-party resources

### DIFF
--- a/experimental/fetchpet/CHANGELOG.md
+++ b/experimental/fetchpet/CHANGELOG.md
@@ -11,13 +11,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **BREAKING**: Consolidate `get_active_claims` and `get_historical_claims` into single `get_claims` tool that returns all claims (both active and historical)
 
+### Added
+
+- Save debug screenshot on login failure for troubleshooting (timestamped in download directory)
+
 ### Fixed
 
 - Fix login timeout caused by `page.waitForURL` hanging when third-party resources fail to load (e.g. blocked analytics scripts). Replace `Promise.all([waitForURL, click])` with `click()` + `waitForFunction()` polling for URL change or dashboard elements
-- Fix false-positive login error detection by narrowing error selector from `[class*="error"]` (matched layout classes) to `.error-text, [role="alert"]` with empty text check
+- Fix false-positive error detection by narrowing error selectors from `[class*="error"]` (matched layout classes) to `.error-text, [role="alert"]` with empty text check (login and claim submission)
 - Fix claim details field selector to support both `<textarea>` and `<input>` elements (site changed form element type)
 - Fix `playwright-extra` import to use two-step import for ESM compatibility
-- Add debug screenshot on login failure for troubleshooting
 - Fix EOB/Invoice document downloads by intercepting popup tabs with blob: URLs instead of relying on browser download events
 - Wire up configurable `TIMEOUT` env var via `page.setDefaultTimeout()`
 - Fix `getClaimDetails` matching logic that always matched the first claim card


### PR DESCRIPTION
## Summary

- Replace `Promise.all([waitForURL, click])` with `click()` + `waitForFunction()` polling for login navigation detection. The previous approach used `page.waitForURL` with the default `'load'` waitUntil, which hangs indefinitely when third-party resources (analytics scripts, ads) fail to load — causing the consistent `page.waitForURL: Timeout 30000ms exceeded` error reported in #329
- Fix false-positive login error detection by narrowing the error selector from `[class*="error"]` (which matched layout CSS classes like `.error-text.error-alignment`) to `.error-text, [role="alert"]` with an empty text check
- Update the claim details field selector to support both `<textarea>` and `<input>` elements, since the Fetch Pet site changed the form element type
- Fix `playwright-extra` ESM import for compatibility
- Add debug screenshot on login failure for troubleshooting

## Root Cause

The Fetch Pet login page loads third-party resources (e.g., `branch.io` analytics) that sometimes return 403 errors or time out. Playwright's `page.waitForURL` with the default `waitUntil: 'load'` waits for **all** resources to finish loading before resolving. When any third-party resource fails, the `load` event never fires, causing the 30-second timeout.

The fix uses `page.waitForFunction()` to poll for URL change (no longer contains "login") or the presence of dashboard navigation elements, which doesn't depend on third-party resource loading.

## Test plan

- [x] Functional tests pass (7/7)
- [x] Integration tests pass (11/11)  
- [x] Manual verification with real credentials via `TestMCPClient` — login succeeds, `get_claims` returns 10 claims, `prepare_claim_to_submit` correctly validates required invoice file

Closes #329

🤖 Generated with [Claude Code](https://claude.com/claude-code)