### PR TITLE
docs: replace Test plan with Verification section in PR guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,9 +39,10 @@ The `## Verification` section documents how you closed the loop — what you _ac
 
 Good examples:
 
-- `[x] Added tests in `experimental/my-server/src/**tests**/``
+- `[x] Added tests in experimental/my-server/src/__tests__/ — ran locally, 8/8 pass`
 - `[x] CI green (lint + tests pass)`
 - `[x] Self-reviewed PR diff — no unintended changes`
+- `[x] Deployed to staging and verified server responds to tool calls with Playwright — list_tools returns expected schema, search returns results`
 
 Bad examples (NEVER do this):
 


### PR DESCRIPTION
## Summary

Updates the root CLAUDE.md to replace the default `## Test plan` PR section (with unchecked checkboxes) with a `## Verification` section that documents what was *actually done* to verify a change works. This ensures agent-opened PRs provide real value to reviewers instead of aspirational TODOs nobody ever completes.

Companion to https://github.com/pulsemcp/agents/pull/1249.

## Verification
- [x] Only the root CLAUDE.md was modified — single focused change
- [x] Pre-commit hooks passed (prettier auto-formatted the file)
- [x] Self-reviewed the diff — new guidance is inserted cleanly between the existing "Git Workflow" bullet list and the "IMPORTANT: Git Branch Management" subsection
- [x] New section uses the exact `## Verification` header as specified
- [x] Explicitly overrides the default Claude Code PR template

🤖 Generated with [Claude Code](https://claude.com/claude-code)