### PR TITLE
docs: require agents to ask for credentials when .env is missing

### DIFF
--- a/.claude/skills/publish-and-pr/SKILL.md
+++ b/.claude/skills/publish-and-pr/SKILL.md
@@ -8,7 +8,7 @@ We are doing a version bump of type (major/minor/patch): $ARGUMENTS
 
 I want you to:
 
-- [ ] Before you start, make sure you have recently run the `manual` test suites (`npm run test:manual`; with valid secrets in place - you can usually find them in a .env file within the MCP server source) and proven the happy path is working. We don't want to accidentally publish a version bump that fails manual tests. **Important**: Update the MANUAL_TESTING.md file with the test results if the server has one.
+- [ ] Before you start, make sure you have recently run the `manual` test suites (`npm run test:manual`; with valid secrets in place - you can usually find them in a .env file within the MCP server source) and proven the happy path is working. We don't want to accidentally publish a version bump that fails manual tests. **Important**: Update the MANUAL_TESTING.md file with the test results if the server has one. **CRITICAL: If the `.env` file is missing or doesn't contain the required API keys/credentials, STOP and ask the user to provide them. Do NOT silently skip manual tests or proceed without credentials.**
 - [ ] Before starting, run `git status` to see current state
 - [ ] Run the publication process for server updates ([PUBLISHING_SERVERS.md](../../../docs/PUBLISHING_SERVERS.md))
 - [ ] **IMMEDIATELY AFTER VERSION BUMP**: Run `git status` to see ALL files modified by npm version command

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -310,6 +310,8 @@ npm run test:manual
 
 **Note**: Always use `.env` files in the MCP server's source root to store API keys and credentials. Never commit these files to version control.
 
+**CRITICAL: If the `.env` file is missing or doesn't contain the required API keys/credentials, STOP and ask the user to provide them.** Do NOT silently skip manual tests or proceed without credentials. Check for the `.env` file BEFORE attempting to run manual tests — if it's missing or looks incomplete, ask the user for the required credentials immediately.
+
 ### CRITICAL: Manual Test Integrity Policy
 
 **Manual tests MUST actually test real functionality against real APIs. No exceptions.**
@@ -433,7 +435,7 @@ Don't add: basic TypeScript fixes, standard npm troubleshooting, obvious file op
 - Breaking changes in tool parameters should be clearly marked in CHANGELOG.md with **BREAKING** prefix to alert users
 - When using `set -e` in shell scripts with npm commands, be aware that `npm view` returns exit code 1 when a package doesn't exist yet - use `|| true` to prevent premature script termination during npm registry propagation checks
 - **For `/publish-and-pr` skill**: This means "stage for publishing and update PR" - it does NOT mean actually publish to npm. The workflow is: bump version → update changelog → commit → push → update PR. NPM publishing happens automatically via CI when PR is merged
-- **Manual Testing Before Publishing**: Always run manual tests (with real API credentials) before staging a version bump to ensure the server works correctly with external APIs
+- **Manual Testing Before Publishing**: Always run manual tests (with real API credentials) before staging a version bump to ensure the server works correctly with external APIs. If the `.env` file with credentials is missing, STOP and ask the user to provide them — do NOT skip manual tests
 - **Git Tag Format for Version Bumps**: When creating git tags for version bumps, use the format `package-name@version` (e.g., `appsignal-mcp-server@0.2.12`, `@pulsemcp/pulse-fetch@0.2.10`). The CI verify-publications workflow expects this exact format, not `server-name-vX.Y.Z`
 - **Manual Testing and CI**: The verify-publications CI check requires that MANUAL_TESTING.md references a commit that's in the PR's history. If you make any commits after running manual tests (even just test fixes), the CI will fail. For test-only fixes, this is a known limitation that doesn't require re-running manual tests. When updating MANUAL_TESTING.md for packaging-only changes, ensure the commit hash matches a commit in the current PR branch
 - **npm Package Files Field**: When specifying files to include in npm packages, use specific glob patterns (e.g., `"build/**/*.js"`) rather than entire directories (e.g., `"build/"`) to ensure proper file permissions and avoid including non-executable files. This prevents "Permission denied" errors when users run the package with npx
@@ -450,6 +452,7 @@ Don't add: basic TypeScript fixes, standard npm troubleshooting, obvious file op
 - Manual tests should run against built code (not source) - create a `run-manual-built.js` script that builds the project first, then runs tests against the compiled JavaScript
 - CI should fail when MANUAL_TESTING.md isn't updated for the current PR, but NOT when tests fail (some failures might be expected due to API limitations)
 - **Manual test setup checklist**: Verify .env exists with real API keys, run `ci:install` to install all workspace dependencies, run `build:test` to build everything including test-mcp-client
+- **CRITICAL: Missing credentials policy**: If the `.env` file is missing or doesn't contain the required API keys/credentials for manual tests, STOP and ask the user to provide them. Do NOT silently skip manual tests or proceed without credentials. Agents must check for `.env` BEFORE running manual tests and prompt the user if it's missing or incomplete
 - **CRITICAL: Manual tests must actually pass against real APIs** - NEVER write tests that skip or gracefully handle missing backend endpoints. If an API endpoint doesn't exist, do not write client code for it. A "passing" test that silently skips on 404 is worse than no test at all because it provides false confidence
 
 ### Monorepo Dependency Management

--- a/docs/PUBLISHING_SERVERS.md
+++ b/docs/PUBLISHING_SERVERS.md
@@ -48,13 +48,14 @@ After staging the publication, update the server's CHANGELOG.md file:
 
 For servers with manual tests (that require real API credentials):
 
-1. Run the manual tests (automatically builds and tests):
+1. **Check for credentials first**: Verify that the `.env` file exists in the MCP server's source root and contains the required API keys. **If the `.env` file is missing or doesn't have the required credentials, STOP and ask the user to provide them. Do NOT skip manual tests or proceed without credentials.**
+2. Run the manual tests (automatically builds and tests):
    ```bash
    npm run test:manual
    ```
-2. Update `MANUAL_TESTING.md` with the test results (overwrite previous results)
-3. Include commit hash, test date/time in PT, and results summary
-4. Use real API credentials from .env for proper testing
+3. Update `MANUAL_TESTING.md` with the test results (overwrite previous results)
+4. Include commit hash, test date/time in PT, and results summary
+5. Use real API credentials from .env for proper testing
 
 Example:
 
@@ -154,7 +155,7 @@ Before creating a PR:
 - [ ] Version bumped using `npm run stage-publish`
 - [ ] CHANGELOG.md updated with new version section
 - [ ] All tests pass (`npm test`, `npm run test:integration`)
-- [ ] Manual tests run and results updated in MANUAL_TESTING.md (if applicable)
+- [ ] Manual tests run and results updated in MANUAL_TESTING.md (if applicable — if `.env` credentials are missing, ask the user for them; do NOT skip)
 - [ ] Build succeeds (`npm run build`)
 - [ ] No sensitive information in code
 - [ ] Git tag created and pushed

--- a/libs/mcp-server-template/CONTRIBUTING.md
+++ b/libs/mcp-server-template/CONTRIBUTING.md
@@ -86,6 +86,7 @@ Manual tests are important when your server interacts with external APIs:
 - Verify actual API integration works correctly
 - Test response shapes and error handling
 - Are NOT run in CI to avoid external dependencies
+- **If the `.env` file is missing or doesn't contain the required API keys/credentials, STOP and ask the user to provide them. Do NOT silently skip manual tests or proceed without credentials.**
 
 ## Testing with a test.ts file
 

--- a/libs/mcp-server-template/MANUAL_TESTING.md
+++ b/libs/mcp-server-template/MANUAL_TESTING.md
@@ -25,6 +25,8 @@ This file tracks the **most recent** manual test results for the NAME MCP server
    # Edit .env with your credentials
    ```
 
+   **CRITICAL: If the `.env` file is missing or doesn't contain the required API keys, STOP and ask the user to provide them. Do NOT silently skip manual tests or proceed without credentials.**
+
 ### First-Time Setup (or after clean checkout)
 
 If you're running manual tests for the first time or in a fresh worktree:

--- a/libs/mcp-server-template/tests/README.md
+++ b/libs/mcp-server-template/tests/README.md
@@ -191,7 +191,9 @@ Manual tests are designed to test the MCP server against real external APIs. The
    OTHER_ENV_VAR=value
    ```
 
-2. Run manual tests:
+2. **Check for credentials**: Before running manual tests, verify the `.env` file exists and contains the required API keys. **If the `.env` file is missing or incomplete, STOP and ask the user to provide the credentials. Do NOT skip manual tests or proceed without them.**
+
+3. Run manual tests:
    ```bash
    npm run test:manual
    ```


### PR DESCRIPTION
## Summary

Updated all instruction files across the repo to explicitly require agents to **STOP and ask the user for credentials** when the `.env` file is missing or doesn't contain the required API keys — rather than silently skipping manual tests.

Previously, instructions mentioned running manual tests "with valid secrets in place" but didn't specify what agents should do when credentials are unavailable. This led to agents silently skipping manual tests, which defeats the purpose of manual testing.

### Files updated:
- **`CLAUDE.md`** — Added credential-check instructions in the Testing Strategy section, Manual Testing Infrastructure learnings, and Publishing Process learnings
- **`.claude/skills/publish-and-pr/SKILL.md`** — Added explicit stop-and-ask requirement to the manual test step
- **`docs/PUBLISHING_SERVERS.md`** — Added credential verification as step 1 before running manual tests, and updated the pre-publication checklist
- **`libs/mcp-server-template/CONTRIBUTING.md`** — Added credential-check bullet to Manual Testing section
- **`libs/mcp-server-template/tests/README.md`** — Added credential verification step before running manual tests
- **`libs/mcp-server-template/MANUAL_TESTING.md`** — Added stop-and-ask requirement in the prerequisites section

## Verification
- [x] Self-reviewed PR diff — all 6 files have consistent, clear instructions requiring agents to stop and ask for credentials
- [x] Prettier formatting passed via pre-commit hooks (lint-staged ran `prettier --write` on all 6 files)
- [x] No code changes — documentation only, so no functional testing needed