### PR TITLE
feat(pulsemcp-cms-admin): add notifications tool group for email isolation

### DIFF
--- a/experimental/pulsemcp-cms-admin/shared/src/tools.ts
+++ b/experimental/pulsemcp-cms-admin/shared/src/tools.ts
@@ -91,6 +91,7 @@ import { getDiscoveredUrlStats } from './tools/get-discovered-url-stats.js';
  * - good_jobs / good_jobs_readonly: GoodJob background job management tools
  * - proctor: Proctor exam execution and result storage tools (write-only, no readonly variant since both tools trigger side effects)
  * - discovered_urls / discovered_urls_readonly: Discovered URL management tools for processing URLs into MCP implementations
+ * - notifications: Notification email tools (send_impl_posted_notif). Separated from server_directory so notification capability can be granted independently.
  */
 export type ToolGroup =
   | 'newsletter'
@@ -115,7 +116,8 @@ export type ToolGroup =
   | 'good_jobs_readonly'
   | 'proctor'
   | 'discovered_urls'
-  | 'discovered_urls_readonly';
+  | 'discovered_urls_readonly'
+  | 'notifications';
 
 /** Base groups without _readonly suffix */
 type BaseToolGroup =
@@ -130,7 +132,8 @@ type BaseToolGroup =
   | 'redirects'
   | 'good_jobs'
   | 'proctor'
-  | 'discovered_urls';
+  | 'discovered_urls'
+  | 'notifications';
 
 interface Tool {
   name: string;
@@ -172,12 +175,13 @@ const ALL_TOOLS: ToolDefinition[] = [
     isWriteOperation: false,
   },
   { factory: saveMCPImplementation, groups: ['server_directory'], isWriteOperation: true },
+  { factory: findProviders, groups: ['server_directory'], isWriteOperation: false },
+  // Notification tools (separated from server_directory for isolation)
   {
     factory: sendMCPImplementationPostingNotification,
-    groups: ['server_directory'],
+    groups: ['notifications'],
     isWriteOperation: true,
   },
-  { factory: findProviders, groups: ['server_directory'], isWriteOperation: false },
   // Official mirror queue tools (also in server_directory)
   {
     factory: getOfficialMirrorQueueItems,
@@ -353,6 +357,7 @@ const VALID_TOOL_GROUPS: ToolGroup[] = [
   'proctor',
   'discovered_urls',
   'discovered_urls_readonly',
+  'notifications',
 ];
 
 /**
@@ -371,6 +376,7 @@ const BASE_TOOL_GROUPS: BaseToolGroup[] = [
   'good_jobs',
   'proctor',
   'discovered_urls',
+  'notifications',
 ];
 
 /**
@@ -465,6 +471,7 @@ function shouldIncludeTool(toolDef: ToolDefinition, enabledGroups: ToolGroup[]):
  * - proctor: Proctor exam execution and result storage tools (write-only, no readonly variant)
  * - discovered_urls: Discovered URL management tools for processing URLs into MCP implementations (read + write)
  * - discovered_urls_readonly: Discovered URL tools (read only - list and stats)
+ * - notifications: Notification email tools - send_impl_posted_notif (write-only, no readonly variant)
  *
  * @param clientFactory - Factory function that creates client instances
  * @param enabledGroups - Optional comma-separated list of enabled tool groups (overrides env var)

--- a/experimental/pulsemcp-cms-admin/tests/integration/toolgroups.integration.test.ts
+++ b/experimental/pulsemcp-cms-admin/tests/integration/toolgroups.integration.test.ts
@@ -90,8 +90,9 @@ describe('PulseMCP CMS Admin - Toolgroups Integration Tests', () => {
     it('should only register server_directory tools (superset)', async () => {
       const tools = await client.listTools();
 
-      // server_directory is a superset: 5 original + 7 official_queue + 5 unofficial_mirrors + 2 official_mirrors + 5 mcp_jsons + 3 mcp_servers = 27
-      expect(tools.tools).toHaveLength(27);
+      // server_directory is a superset: 4 original + 7 official_queue + 5 unofficial_mirrors + 2 official_mirrors + 5 mcp_jsons + 3 mcp_servers = 26
+      // (send_impl_posted_notif moved to separate 'notifications' group)
+      expect(tools.tools).toHaveLength(26);
       const toolNames = tools.tools.map((t) => t.name);
 
       // Server directory core tools should be present
@@ -99,7 +100,9 @@ describe('PulseMCP CMS Admin - Toolgroups Integration Tests', () => {
       expect(toolNames).toContain('get_draft_mcp_implementations');
       expect(toolNames).toContain('find_providers');
       expect(toolNames).toContain('save_mcp_implementation');
-      expect(toolNames).toContain('send_impl_posted_notif');
+
+      // send_impl_posted_notif is now in the 'notifications' group, NOT server_directory
+      expect(toolNames).not.toContain('send_impl_posted_notif');
 
       // Tools from overlapping groups should also be present
       expect(toolNames).toContain('get_official_mirror_queue_items');
@@ -161,8 +164,8 @@ describe('PulseMCP CMS Admin - Toolgroups Integration Tests', () => {
     it('should register newsletter and server_directory tools', async () => {
       const tools = await client.listTools();
 
-      // 6 newsletter + 27 server_directory (superset) = 33
-      expect(tools.tools).toHaveLength(33);
+      // 6 newsletter + 26 server_directory (superset, without send_impl_posted_notif) = 32
+      expect(tools.tools).toHaveLength(32);
       const toolNames = tools.tools.map((t) => t.name);
 
       // All newsletter tools should be present
@@ -178,10 +181,12 @@ describe('PulseMCP CMS Admin - Toolgroups Integration Tests', () => {
       expect(toolNames).toContain('get_draft_mcp_implementations');
       expect(toolNames).toContain('find_providers');
       expect(toolNames).toContain('save_mcp_implementation');
-      expect(toolNames).toContain('send_impl_posted_notif');
       expect(toolNames).toContain('get_official_mirror_queue_items');
       expect(toolNames).toContain('get_unofficial_mirrors');
       expect(toolNames).toContain('list_mcp_servers');
+
+      // send_impl_posted_notif is NOT here (it's in the 'notifications' group)
+      expect(toolNames).not.toContain('send_impl_posted_notif');
     });
   });
 
@@ -305,18 +310,20 @@ describe('PulseMCP CMS Admin - Toolgroups Integration Tests', () => {
     it('should register all tools by default', async () => {
       const tools = await client.listTools();
 
-      // 6 newsletter + 5 server_directory + 7 official_queue + 5 unofficial_mirrors + 2 official_mirrors + 2 tenants + 5 mcp_jsons + 3 mcp_servers + 5 redirects + 10 good_jobs + 2 proctor = 52 tools
-      expect(tools.tools).toHaveLength(52);
+      // 6 newsletter + 4 server_directory + 7 official_queue + 5 unofficial_mirrors + 2 official_mirrors + 2 tenants + 5 mcp_jsons + 3 mcp_servers + 5 redirects + 10 good_jobs + 2 proctor + 3 discovered_urls + 1 notifications = 55 tools
+      expect(tools.tools).toHaveLength(55);
       const toolNames = tools.tools.map((t) => t.name);
 
       // Newsletter tools
       expect(toolNames).toContain('get_newsletter_posts');
 
-      // Server queue tools
+      // Server directory tools
       expect(toolNames).toContain('search_mcp_implementations');
       expect(toolNames).toContain('get_draft_mcp_implementations');
       expect(toolNames).toContain('find_providers');
       expect(toolNames).toContain('save_mcp_implementation');
+
+      // Notification tools (separate group)
       expect(toolNames).toContain('send_impl_posted_notif');
 
       // Official queue tools
@@ -365,6 +372,51 @@ describe('PulseMCP CMS Admin - Toolgroups Integration Tests', () => {
       // Proctor tools
       expect(toolNames).toContain('run_exam_for_mirror');
       expect(toolNames).toContain('save_results_for_mirror');
+
+      // Discovered URLs tools
+      expect(toolNames).toContain('list_discovered_urls');
+      expect(toolNames).toContain('mark_discovered_url_processed');
+      expect(toolNames).toContain('get_discovered_url_stats');
+    });
+  });
+
+  describe('notifications group only', () => {
+    let client: TestMCPClient;
+
+    beforeAll(async () => {
+      const serverPath = path.join(
+        __dirname,
+        '../../local/build/local/src/index.integration-with-mock.js'
+      );
+
+      client = new TestMCPClient({
+        serverPath: serverPath,
+        env: {
+          ...process.env,
+          TOOL_GROUPS: 'notifications',
+          PULSEMCP_MOCK_DATA: JSON.stringify({}),
+        },
+      });
+      await client.connect();
+    });
+
+    afterAll(async () => {
+      await client.disconnect();
+    });
+
+    it('should only register notification tools', async () => {
+      const tools = await client.listTools();
+
+      expect(tools.tools).toHaveLength(1);
+      const toolNames = tools.tools.map((t) => t.name);
+
+      // Notification tools should be present
+      expect(toolNames).toContain('send_impl_posted_notif');
+
+      // Other groups should NOT be present
+      expect(toolNames).not.toContain('search_mcp_implementations');
+      expect(toolNames).not.toContain('get_newsletter_posts');
+      expect(toolNames).not.toContain('get_official_mirror_queue_items');
     });
   });
 


### PR DESCRIPTION
## Summary
- Move `send_impl_posted_notif` from `server_directory` to a dedicated `notifications` tool group
- This allows notification email capability to be granted independently from server directory read/write access
- Add `notifications` to `ToolGroup`, `BaseToolGroup`, `VALID_TOOL_GROUPS`, and `BASE_TOOL_GROUPS`
- Update integration tests to reflect the new group structure

## Motivation
The new `server-discovery` agent in Agent Orchestrator needs `server_directory` write access (to save implementations) but should NOT have notification capability during its processing phase. By isolating `send_impl_posted_notif` into its own `notifications` group, we can grant it only to the notification phase via a dedicated MCP server config.

## Breaking Changes
- `send_impl_posted_notif` is no longer available when `TOOL_GROUPS=server_directory` — consumers that relied on this (e.g., old `server-queue-poster` agent) need to add `notifications` to their `TOOL_GROUPS` or use the default (all groups) configuration.

## Test plan
- [x] All 12 toolgroups integration tests pass
- [x] New `notifications group only` test verifies the group contains exactly `send_impl_posted_notif`
- [x] `server_directory` group now has 26 tools (was 27) — confirms `send_impl_posted_notif` removed
- [x] Default (all groups) now has 55 tools — includes notifications + discovered_urls from PR #365

🤖 Generated with [Claude Code](https://claude.com/claude-code)