### PR TITLE
Add known_missing flags to list_proctor_runs tool

### DIFF
--- a/experimental/pulsemcp-cms-admin/shared/src/pulsemcp-admin-client/lib/get-proctor-runs.ts
+++ b/experimental/pulsemcp-cms-admin/shared/src/pulsemcp-admin-client/lib/get-proctor-runs.ts
@@ -17,6 +17,8 @@ interface RailsProctorRun {
   num_tools: number | null;
   packages: string[];
   remotes: string[];
+  known_missing_init_tools_list: boolean;
+  known_missing_auth_check: boolean;
 }
 
 interface RailsResponse {
@@ -113,6 +115,8 @@ export async function getProctorRuns(
       num_tools: run.num_tools,
       packages: run.packages,
       remotes: run.remotes,
+      known_missing_init_tools_list: run.known_missing_init_tools_list || false,
+      known_missing_auth_check: run.known_missing_auth_check || false,
     })),
     pagination: {
       current_page: data.meta.current_page,

--- a/experimental/pulsemcp-cms-admin/shared/src/tools/list-proctor-runs.ts
+++ b/experimental/pulsemcp-cms-admin/shared/src/tools/list-proctor-runs.ts
@@ -168,6 +168,14 @@ Use cases:
             content += `   Remotes: ${run.remotes.join(', ')}\n`;
           }
 
+          if (run.known_missing_init_tools_list) {
+            content += `   Known Missing Init Tools List: yes\n`;
+          }
+
+          if (run.known_missing_auth_check) {
+            content += `   Known Missing Auth Check: yes\n`;
+          }
+
           content += '\n';
         }
 

--- a/experimental/pulsemcp-cms-admin/shared/src/types.ts
+++ b/experimental/pulsemcp-cms-admin/shared/src/types.ts
@@ -913,6 +913,8 @@ export interface ProctorRun {
   num_tools: number | null;
   packages: string[];
   remotes: string[];
+  known_missing_init_tools_list: boolean;
+  known_missing_auth_check: boolean;
 }
 
 export interface ProctorRunsResponse {

--- a/experimental/pulsemcp-cms-admin/tests/functional/list-proctor-runs.test.ts
+++ b/experimental/pulsemcp-cms-admin/tests/functional/list-proctor-runs.test.ts
@@ -99,6 +99,8 @@ describe('list_proctor_runs', () => {
             num_tools: 5,
             packages: ['npm'],
             remotes: ['streamable-http'],
+            known_missing_init_tools_list: false,
+            known_missing_auth_check: false,
           },
           {
             id: 789,
@@ -117,6 +119,8 @@ describe('list_proctor_runs', () => {
             num_tools: null,
             packages: [],
             remotes: [],
+            known_missing_init_tools_list: false,
+            known_missing_auth_check: false,
           },
         ],
         pagination: {


### PR DESCRIPTION
## Summary
- Adds `known_missing_init_tools_list` and `known_missing_auth_check` boolean fields to the `ProctorRun` interface, `RailsProctorRun` interface, and the data mapping in `get-proctor-runs.ts`
- Renders these flags in the `list_proctor_runs` tool output when `true`, so the Proctor runner agent can identify and skip exams that are known to fail
- Updates test mock data to include the new fields with `false` defaults

## Test plan
- [ ] Verify existing `list-proctor-runs` tests pass with the new fields in mock data
- [ ] Confirm `known_missing_*` flags render in tool output only when `true`
- [ ] Validate that the API mapping defaults to `false` when the fields are absent from the Rails response

🤖 Generated with [Claude Code](https://claude.com/claude-code)