### PR TITLE
Gitignore .claude/skills/ directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,6 @@ mcp-json-profiles/.secrets
 
 # Test publish directories
 **/.test-publish/
+
+# Claude skills - auto-generated, should not be version-controlled
+**/.claude/skills/


### PR DESCRIPTION
## Summary
- Added `**/.claude/skills/` pattern to `.gitignore` to prevent auto-generated Claude skill files from being version-controlled at any directory depth
- No `.claude/skills/` files were currently tracked, so no `git rm --cached` was needed

## Verification
- [x] Verified pattern matches at root level: `git check-ignore --no-index .claude/skills/foo.md` → matched
- [x] Verified pattern matches at nested depth: `git check-ignore --no-index nested/dir/.claude/skills/bar.md` → matched
- [x] Confirmed no `.claude/skills/` files are currently tracked: `git ls-files | grep '.claude/skills/'` → no output
- [x] Self-reviewed PR diff — single `.gitignore` change, no unintended modifications

🤖 Generated with [Claude Code](https://claude.com/claude-code)