### PR TITLE
Sync agent-orchestrator from monorepo

### DIFF
--- a/experimental/agent-orchestrator/CHANGELOG.md
+++ b/experimental/agent-orchestrator/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.3] - 2026-04-11
+
+### Changed
+
+- Internal: verify automated distribution pipeline (retry with gh CLI fix)
+
+## [0.6.2] - 2026-04-11
+
+### Changed
+
+- Internal: verify automated distribution pipeline (retry with path fix)
+
+## [0.6.1] - 2026-04-11
+
+### Changed
+
+- Internal: verify automated distribution pipeline
+
 ## [0.6.0] - 2026-04-11
 
 ### Changed

--- a/experimental/agent-orchestrator/README.md
+++ b/experimental/agent-orchestrator/README.md
@@ -18,22 +18,22 @@ MCP server for PulseMCP's agent-orchestrator: a Claude Code + MCP-powered agent-
 
 ### Tools
 
-| Tool                       | Tool Group    | Read/Write | Description                                                                                                                                                                             |
-| -------------------------- | ------------- | ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `quick_search_sessions`    | sessions      | read       | Quick title-based search/list sessions with optional ID lookup, title query, and status filter                                                                                          |
-| `get_session`              | sessions      | read       | Get detailed session info with optional logs, transcripts, and transcript format (text/json)                                                                                            |
-| `get_configs`              | sessions      | read       | Fetch all static configuration (MCP servers, agent roots, stop conditions)                                                                                                              |
-| `get_transcript_archive`   | sessions      | read       | Get download URL and metadata for the transcript archive zip file                                                                                                                       |
-| `start_session`            | sessions      | write      | Create and start a new agent session                                                                                                                                                    |
+| Tool                       | Tool Group    | Read/Write | Description                                                                                                                                                 |
+| -------------------------- | ------------- | ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `quick_search_sessions`    | sessions      | read       | Quick title-based search/list sessions with optional ID lookup, title query, and status filter                                                              |
+| `get_session`              | sessions      | read       | Get detailed session info with optional logs, transcripts, and transcript format (text/json)                                                                |
+| `get_configs`              | sessions      | read       | Fetch all static configuration (MCP servers, agent roots, stop conditions)                                                                                  |
+| `get_transcript_archive`   | sessions      | read       | Get download URL and metadata for the transcript archive zip file                                                                                           |
+| `start_session`            | sessions      | write      | Create and start a new agent session                                                                                                                        |
 | `action_session`           | sessions      | write      | Perform actions: follow_up, pause, restart, archive, unarchive, change_mcp_servers, change_model, fork, refresh, refresh_all, update_notes, update_title, toggle_favorite, bulk_archive |
-| `manage_enqueued_messages` | sessions      | write      | Manage session message queue: list, get, create, update, delete, reorder, interrupt                                                                                                     |
-| `get_notifications`        | notifications | read       | Get/list notifications and badge count                                                                                                                                                  |
-| `send_push_notification`   | notifications | write      | Send a push notification about a session needing human attention                                                                                                                        |
-| `action_notification`      | notifications | write      | Mark read, mark all read, dismiss, dismiss all read notifications                                                                                                                       |
-| `search_triggers`          | triggers      | read       | Search/list automation triggers with optional channel info                                                                                                                              |
-| `action_trigger`           | triggers      | write      | Create, update, delete, toggle automation triggers                                                                                                                                      |
-| `get_system_health`        | health        | read       | Get system health report and optional CLI status                                                                                                                                        |
-| `action_health`            | health        | write      | System maintenance: cleanup_processes, retry_sessions, archive_old, cli_refresh, cli_clear_cache                                                                                        |
+| `manage_enqueued_messages` | sessions      | write      | Manage session message queue: list, get, create, update, delete, reorder, interrupt                                                                         |
+| `get_notifications`        | notifications | read       | Get/list notifications and badge count                                                                                                                      |
+| `send_push_notification`   | notifications | write      | Send a push notification about a session needing human attention                                                                                            |
+| `action_notification`      | notifications | write      | Mark read, mark all read, dismiss, dismiss all read notifications                                                                                           |
+| `search_triggers`          | triggers      | read       | Search/list automation triggers with optional channel info                                                                                                  |
+| `action_trigger`           | triggers      | write      | Create, update, delete, toggle automation triggers                                                                                                          |
+| `get_system_health`        | health        | read       | Get system health report and optional CLI status                                                                                                            |
+| `action_health`            | health        | write      | System maintenance: cleanup_processes, retry_sessions, archive_old, cli_refresh, cli_clear_cache                                                            |
 
 ### Resources
 

--- a/experimental/agent-orchestrator/local/package.json
+++ b/experimental/agent-orchestrator/local/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-orchestrator-mcp-server",
-  "version": "0.6.0",
+  "version": "0.6.3",
   "description": "Local implementation of agent-orchestrator MCP server",
   "main": "build/index.js",
   "type": "module",

--- a/experimental/agent-orchestrator/package.json
+++ b/experimental/agent-orchestrator/package.json
@@ -11,12 +11,9 @@
   "type": "module",
   "scripts": {
     "install-all": "npm install && cd local && npm install && cd ../shared && npm install",
-    "ci:install": "npm ci && cd shared && npm ci && cd ../local && npm ci && cd ../../../libs/test-mcp-client && npm ci --ignore-scripts",
     "build": "node ../../scripts/build-mcp-server.js",
-    "build:test": "node ../../scripts/build-mcp-server.js && cd ../../libs/test-mcp-client && npm run build",
     "clean": "find . -name '*.js' -not -path './node_modules/*' -not -path './*/node_modules/*' -not -path './local/build/*' -not -path './shared/build/*' -not -path './*/build/*' -delete && find . -name '*.js.map' -not -path './node_modules/*' -not -path './*/node_modules/*' -not -path './local/build/*' -not -path './shared/build/*' -not -path './*/build/*' -delete",
     "dev": "cd local && npm run dev",
-    "test": "echo \"Tests run in internal monorepo (pulsemcp/pulsemcp)\"",
     "lint": "cd ../.. && npm run lint",
     "lint:fix": "cd ../.. && npm run lint:fix",
     "format": "cd ../.. && npm run format",


### PR DESCRIPTION
## Summary

Synced `agent-orchestrator` from internal monorepo (pulsemcp/pulsemcp @ `7b78b98c`).

## Changes


### Changed

- Internal: verify automated distribution pipeline (retry with gh CLI fix)

## Verification

- [x] Distribution script ran successfully
- [x] File diff shows only incremental changes from previous sync
- [x] No test files or internal docs included