### PR TITLE
Sync agent-orchestrator from monorepo

### DIFF
--- a/experimental/agent-orchestrator/shared/tsconfig.json
+++ b/experimental/agent-orchestrator/shared/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "target": "es2022",
-    "module": "esnext",
-    "moduleResolution": "node",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "esModuleInterop": true,
     "strict": true,
     "skipLibCheck": true,


### PR DESCRIPTION
## Summary

Synced `agent-orchestrator` from internal monorepo (pulsemcp/pulsemcp @ `30012a50`).

## Changes


- Migration verification: no-op patch version bump to validate internal→public distribution pipeline

## Verification

- [x] Distribution script ran successfully
- [x] File diff shows only incremental changes from previous sync
- [x] No test files or internal docs included