### PR TITLE
Sync 1 servers from monorepo

### DIFF
--- a/experimental/agent-orchestrator/local/prepare-publish.js
+++ b/experimental/agent-orchestrator/local/prepare-publish.js
@@ -22,7 +22,12 @@ async function prepare() {
   const sharedDir = join(__dirname, '../shared');
   console.log('Building shared directory...');
   try {
-    execSync('npm install && npm run build', { cwd: sharedDir, stdio: 'inherit' });
+    execSync('npm install', { cwd: sharedDir, stdio: 'inherit' });
+    // Use npx to find tsc — npm workspace hoisting places binaries in the
+    // workspace root's node_modules/.bin/, not in shared/node_modules/.bin/,
+    // so bare `tsc` (via `npm run build`) fails. npx searches up the directory
+    // tree and finds the hoisted binary.
+    execSync('npx tsc', { cwd: sharedDir, stdio: 'inherit' });
   } catch (e) {
     console.error('Failed to build shared directory:', e.message);
     process.exit(1);


### PR DESCRIPTION
## Summary

Bulk sync of **1 servers** from internal monorepo (pulsemcp/pulsemcp @ `3d2f7fef`).

### Servers synced

- \`agent-orchestrator\`

## Verification

- [x] Distribution script ran successfully for all 1 servers
- [x] File diff shows only incremental changes from previous sync
- [x] No test files or internal docs included