### PR TITLE
Fix verify-publications CI gating and npx tsc resolution

### DIFF
--- a/.github/workflows/ci-build-test-checks.yml
+++ b/.github/workflows/ci-build-test-checks.yml
@@ -56,10 +56,10 @@ jobs:
               });
               
               // Filter to only the checks we care about (exclude this workflow)
-              const relevantChecks = checkRuns.data.check_runs.filter(run => 
-                run.name !== 'CI Build & Test Checks Passed' && 
+              const relevantChecks = checkRuns.data.check_runs.filter(run =>
+                run.name !== 'CI Build & Test Checks Passed' &&
                 run.app.slug === 'github-actions' &&
-                (run.name.includes('MCP Server') || run.name === 'Lint & Type Check' || run.name === 'Validate Publish Files')
+                (run.name.includes('MCP Server') || run.name === 'Lint & Type Check' || run.name === 'Validate Publish Files' || run.name === 'verify-publications')
               );
               
               // Group by name and get latest run
@@ -116,10 +116,10 @@ jobs:
               per_page: 100
             });
 
-            const finalOtherChecks = finalCheckRuns.data.check_runs.filter(run => 
-              run.name !== 'CI Build & Test Checks Passed' && 
+            const finalOtherChecks = finalCheckRuns.data.check_runs.filter(run =>
+              run.name !== 'CI Build & Test Checks Passed' &&
               run.app.slug === 'github-actions' &&
-              (run.name.includes('MCP Server') || run.name === 'Lint & Type Check' || run.name === 'Validate Publish Files')
+              (run.name.includes('MCP Server') || run.name === 'Lint & Type Check' || run.name === 'Validate Publish Files' || run.name === 'verify-publications')
             );
 
             if (finalOtherChecks.length === 0) {

--- a/experimental/agent-orchestrator/local/prepare-publish.js
+++ b/experimental/agent-orchestrator/local/prepare-publish.js
@@ -23,11 +23,9 @@ async function prepare() {
   console.log('Building shared directory...');
   try {
     execSync('npm install', { cwd: sharedDir, stdio: 'inherit' });
-    // Use npx to find tsc — npm workspace hoisting places binaries in the
-    // workspace root's node_modules/.bin/, not in shared/node_modules/.bin/,
-    // so bare `tsc` (via `npm run build`) fails. npx searches up the directory
-    // tree and finds the hoisted binary.
-    execSync('npx tsc', { cwd: sharedDir, stdio: 'inherit' });
+    // Use --package typescript to ensure npx resolves the real TypeScript
+    // compiler, not the unrelated `tsc` npm package.
+    execSync('npx --package typescript tsc', { cwd: sharedDir, stdio: 'inherit' });
   } catch (e) {
     console.error('Failed to build shared directory:', e.message);
     process.exit(1);
@@ -47,7 +45,7 @@ async function prepare() {
   // Now build the local package
   console.log('Building local package...');
   try {
-    execSync('npx tsc && npx tsc -p tsconfig.integration.json', { stdio: 'inherit' });
+    execSync('npx --package typescript tsc && npx --package typescript tsc -p tsconfig.integration.json', { stdio: 'inherit' });
   } catch (e) {
     console.error('Failed to build local package:', e.message);
     process.exit(1);

--- a/experimental/agent-orchestrator/local/prepare-publish.js
+++ b/experimental/agent-orchestrator/local/prepare-publish.js
@@ -45,7 +45,10 @@ async function prepare() {
   // Now build the local package
   console.log('Building local package...');
   try {
-    execSync('npx --package typescript tsc && npx --package typescript tsc -p tsconfig.integration.json', { stdio: 'inherit' });
+    execSync(
+      'npx --package typescript tsc && npx --package typescript tsc -p tsconfig.integration.json',
+      { stdio: 'inherit' }
+    );
   } catch (e) {
     console.error('Failed to build local package:', e.message);
     process.exit(1);

--- a/experimental/appsignal/local/prepare-publish.js
+++ b/experimental/appsignal/local/prepare-publish.js
@@ -42,7 +42,10 @@ async function prepare() {
   // Now build the local package
   console.log('Building local package...');
   try {
-    execSync('npx --package typescript tsc && npx --package typescript tsc -p tsconfig.integration.json', { stdio: 'inherit' });
+    execSync(
+      'npx --package typescript tsc && npx --package typescript tsc -p tsconfig.integration.json',
+      { stdio: 'inherit' }
+    );
   } catch (e) {
     console.error('Failed to build local package:', e.message);
     process.exit(1);

--- a/experimental/appsignal/local/prepare-publish.js
+++ b/experimental/appsignal/local/prepare-publish.js
@@ -42,7 +42,7 @@ async function prepare() {
   // Now build the local package
   console.log('Building local package...');
   try {
-    execSync('npx tsc && npx tsc -p tsconfig.integration.json', { stdio: 'inherit' });
+    execSync('npx --package typescript tsc && npx --package typescript tsc -p tsconfig.integration.json', { stdio: 'inherit' });
   } catch (e) {
     console.error('Failed to build local package:', e.message);
     process.exit(1);

--- a/experimental/claude-code-agent/local/prepare-publish.js
+++ b/experimental/claude-code-agent/local/prepare-publish.js
@@ -42,7 +42,10 @@ async function prepare() {
   // Now build the local package
   console.log('Building local package...');
   try {
-    execSync('npx --package typescript tsc && npx --package typescript tsc -p tsconfig.integration.json', { stdio: 'inherit' });
+    execSync(
+      'npx --package typescript tsc && npx --package typescript tsc -p tsconfig.integration.json',
+      { stdio: 'inherit' }
+    );
   } catch (e) {
     console.error('Failed to build local package:', e.message);
     process.exit(1);

--- a/experimental/claude-code-agent/local/prepare-publish.js
+++ b/experimental/claude-code-agent/local/prepare-publish.js
@@ -42,7 +42,7 @@ async function prepare() {
   // Now build the local package
   console.log('Building local package...');
   try {
-    execSync('npx tsc && npx tsc -p tsconfig.integration.json', { stdio: 'inherit' });
+    execSync('npx --package typescript tsc && npx --package typescript tsc -p tsconfig.integration.json', { stdio: 'inherit' });
   } catch (e) {
     console.error('Failed to build local package:', e.message);
     process.exit(1);

--- a/experimental/dynamodb/local/prepare-publish.js
+++ b/experimental/dynamodb/local/prepare-publish.js
@@ -42,7 +42,10 @@ async function prepare() {
   // Now build the local package
   console.log('Building local package...');
   try {
-    execSync('npx --package typescript tsc && npx --package typescript tsc -p tsconfig.integration.json', { stdio: 'inherit' });
+    execSync(
+      'npx --package typescript tsc && npx --package typescript tsc -p tsconfig.integration.json',
+      { stdio: 'inherit' }
+    );
   } catch (e) {
     console.error('Failed to build local package:', e.message);
     process.exit(1);

--- a/experimental/dynamodb/local/prepare-publish.js
+++ b/experimental/dynamodb/local/prepare-publish.js
@@ -42,7 +42,7 @@ async function prepare() {
   // Now build the local package
   console.log('Building local package...');
   try {
-    execSync('npx tsc && npx tsc -p tsconfig.integration.json', { stdio: 'inherit' });
+    execSync('npx --package typescript tsc && npx --package typescript tsc -p tsconfig.integration.json', { stdio: 'inherit' });
   } catch (e) {
     console.error('Failed to build local package:', e.message);
     process.exit(1);

--- a/experimental/fetchpet/local/prepare-publish.js
+++ b/experimental/fetchpet/local/prepare-publish.js
@@ -42,7 +42,10 @@ async function prepare() {
   // Now build the local package
   console.log('Building local package...');
   try {
-    execSync('npx --package typescript tsc && npx --package typescript tsc -p tsconfig.integration.json', { stdio: 'inherit' });
+    execSync(
+      'npx --package typescript tsc && npx --package typescript tsc -p tsconfig.integration.json',
+      { stdio: 'inherit' }
+    );
   } catch (e) {
     console.error('Failed to build local package:', e.message);
     process.exit(1);

--- a/experimental/fetchpet/local/prepare-publish.js
+++ b/experimental/fetchpet/local/prepare-publish.js
@@ -42,7 +42,7 @@ async function prepare() {
   // Now build the local package
   console.log('Building local package...');
   try {
-    execSync('npx tsc && npx tsc -p tsconfig.integration.json', { stdio: 'inherit' });
+    execSync('npx --package typescript tsc && npx --package typescript tsc -p tsconfig.integration.json', { stdio: 'inherit' });
   } catch (e) {
     console.error('Failed to build local package:', e.message);
     process.exit(1);

--- a/experimental/fly-io/local/prepare-publish.js
+++ b/experimental/fly-io/local/prepare-publish.js
@@ -42,7 +42,10 @@ async function prepare() {
   // Now build the local package
   console.log('Building local package...');
   try {
-    execSync('npx --package typescript tsc && npx --package typescript tsc -p tsconfig.integration.json', { stdio: 'inherit' });
+    execSync(
+      'npx --package typescript tsc && npx --package typescript tsc -p tsconfig.integration.json',
+      { stdio: 'inherit' }
+    );
   } catch (e) {
     console.error('Failed to build local package:', e.message);
     process.exit(1);

--- a/experimental/fly-io/local/prepare-publish.js
+++ b/experimental/fly-io/local/prepare-publish.js
@@ -42,7 +42,7 @@ async function prepare() {
   // Now build the local package
   console.log('Building local package...');
   try {
-    execSync('npx tsc && npx tsc -p tsconfig.integration.json', { stdio: 'inherit' });
+    execSync('npx --package typescript tsc && npx --package typescript tsc -p tsconfig.integration.json', { stdio: 'inherit' });
   } catch (e) {
     console.error('Failed to build local package:', e.message);
     process.exit(1);

--- a/experimental/gcs/local/prepare-publish.js
+++ b/experimental/gcs/local/prepare-publish.js
@@ -42,7 +42,10 @@ async function prepare() {
   // Now build the local package
   console.log('Building local package...');
   try {
-    execSync('npx --package typescript tsc && npx --package typescript tsc -p tsconfig.integration.json', { stdio: 'inherit' });
+    execSync(
+      'npx --package typescript tsc && npx --package typescript tsc -p tsconfig.integration.json',
+      { stdio: 'inherit' }
+    );
   } catch (e) {
     console.error('Failed to build local package:', e.message);
     process.exit(1);

--- a/experimental/gcs/local/prepare-publish.js
+++ b/experimental/gcs/local/prepare-publish.js
@@ -42,7 +42,7 @@ async function prepare() {
   // Now build the local package
   console.log('Building local package...');
   try {
-    execSync('npx tsc && npx tsc -p tsconfig.integration.json', { stdio: 'inherit' });
+    execSync('npx --package typescript tsc && npx --package typescript tsc -p tsconfig.integration.json', { stdio: 'inherit' });
   } catch (e) {
     console.error('Failed to build local package:', e.message);
     process.exit(1);

--- a/experimental/gmail/local/prepare-publish.js
+++ b/experimental/gmail/local/prepare-publish.js
@@ -36,7 +36,7 @@ async function preparePublish() {
   execSync('node setup-dev.js', { cwd: __dirname, stdio: 'inherit' });
 
   console.log('Building local module...');
-  execSync('npx tsc', { cwd: __dirname, stdio: 'inherit' });
+  execSync('npx --package typescript tsc', { cwd: __dirname, stdio: 'inherit' });
 
   // Remove symlink and copy actual files
   const sharedPath = join(__dirname, 'shared');

--- a/experimental/good-eggs/local/prepare-publish.js
+++ b/experimental/good-eggs/local/prepare-publish.js
@@ -42,7 +42,10 @@ async function prepare() {
   // Now build the local package
   console.log('Building local package...');
   try {
-    execSync('npx --package typescript tsc && npx --package typescript tsc -p tsconfig.integration.json', { stdio: 'inherit' });
+    execSync(
+      'npx --package typescript tsc && npx --package typescript tsc -p tsconfig.integration.json',
+      { stdio: 'inherit' }
+    );
   } catch (e) {
     console.error('Failed to build local package:', e.message);
     process.exit(1);

--- a/experimental/good-eggs/local/prepare-publish.js
+++ b/experimental/good-eggs/local/prepare-publish.js
@@ -42,7 +42,7 @@ async function prepare() {
   // Now build the local package
   console.log('Building local package...');
   try {
-    execSync('npx tsc && npx tsc -p tsconfig.integration.json', { stdio: 'inherit' });
+    execSync('npx --package typescript tsc && npx --package typescript tsc -p tsconfig.integration.json', { stdio: 'inherit' });
   } catch (e) {
     console.error('Failed to build local package:', e.message);
     process.exit(1);

--- a/experimental/google-calendar/local/prepare-publish.js
+++ b/experimental/google-calendar/local/prepare-publish.js
@@ -28,7 +28,7 @@ async function preparePublish() {
   execSync('node setup-dev.js', { cwd: __dirname, stdio: 'inherit' });
 
   console.log('Building local module...');
-  execSync('npx tsc', { cwd: __dirname, stdio: 'inherit' });
+  execSync('npx --package typescript tsc', { cwd: __dirname, stdio: 'inherit' });
 
   // Remove symlink and copy actual files
   const sharedPath = join(__dirname, 'shared');

--- a/experimental/google-flights/local/prepare-publish.js
+++ b/experimental/google-flights/local/prepare-publish.js
@@ -41,7 +41,7 @@ async function prepare() {
   // Now build the local package
   console.log('Building local package...');
   try {
-    execSync('npx tsc', { stdio: 'inherit' });
+    execSync('npx --package typescript tsc', { stdio: 'inherit' });
   } catch (e) {
     console.error('Failed to build local package:', e.message);
     process.exit(1);

--- a/experimental/hatchbox/local/prepare-publish.js
+++ b/experimental/hatchbox/local/prepare-publish.js
@@ -42,7 +42,10 @@ async function prepare() {
   // Now build the local package
   console.log('Building local package...');
   try {
-    execSync('npx --package typescript tsc && npx --package typescript tsc -p tsconfig.integration.json', { stdio: 'inherit' });
+    execSync(
+      'npx --package typescript tsc && npx --package typescript tsc -p tsconfig.integration.json',
+      { stdio: 'inherit' }
+    );
   } catch (e) {
     console.error('Failed to build local package:', e.message);
     process.exit(1);

--- a/experimental/hatchbox/local/prepare-publish.js
+++ b/experimental/hatchbox/local/prepare-publish.js
@@ -42,7 +42,7 @@ async function prepare() {
   // Now build the local package
   console.log('Building local package...');
   try {
-    execSync('npx tsc && npx tsc -p tsconfig.integration.json', { stdio: 'inherit' });
+    execSync('npx --package typescript tsc && npx --package typescript tsc -p tsconfig.integration.json', { stdio: 'inherit' });
   } catch (e) {
     console.error('Failed to build local package:', e.message);
     process.exit(1);

--- a/experimental/langfuse/local/prepare-publish.js
+++ b/experimental/langfuse/local/prepare-publish.js
@@ -29,7 +29,7 @@ async function prepare() {
 
   console.log('Building local package...');
   try {
-    execSync('npx tsc && npx tsc -p tsconfig.integration.json', { stdio: 'inherit' });
+    execSync('npx --package typescript tsc && npx --package typescript tsc -p tsconfig.integration.json', { stdio: 'inherit' });
   } catch (e) {
     console.error('Failed to build local package:', e.message);
     process.exit(1);

--- a/experimental/langfuse/local/prepare-publish.js
+++ b/experimental/langfuse/local/prepare-publish.js
@@ -29,7 +29,10 @@ async function prepare() {
 
   console.log('Building local package...');
   try {
-    execSync('npx --package typescript tsc && npx --package typescript tsc -p tsconfig.integration.json', { stdio: 'inherit' });
+    execSync(
+      'npx --package typescript tsc && npx --package typescript tsc -p tsconfig.integration.json',
+      { stdio: 'inherit' }
+    );
   } catch (e) {
     console.error('Failed to build local package:', e.message);
     process.exit(1);

--- a/experimental/onepassword/local/prepare-publish.js
+++ b/experimental/onepassword/local/prepare-publish.js
@@ -55,7 +55,10 @@ async function prepare() {
   // Now build the local package
   console.log('Building local package...');
   try {
-    execSync('npx --package typescript tsc && npx --package typescript tsc -p tsconfig.integration.json', { stdio: 'inherit' });
+    execSync(
+      'npx --package typescript tsc && npx --package typescript tsc -p tsconfig.integration.json',
+      { stdio: 'inherit' }
+    );
   } catch (e) {
     console.error('Failed to build local package:', e.message);
     process.exit(1);

--- a/experimental/onepassword/local/prepare-publish.js
+++ b/experimental/onepassword/local/prepare-publish.js
@@ -55,7 +55,7 @@ async function prepare() {
   // Now build the local package
   console.log('Building local package...');
   try {
-    execSync('npx tsc && npx tsc -p tsconfig.integration.json', { stdio: 'inherit' });
+    execSync('npx --package typescript tsc && npx --package typescript tsc -p tsconfig.integration.json', { stdio: 'inherit' });
   } catch (e) {
     console.error('Failed to build local package:', e.message);
     process.exit(1);

--- a/experimental/playwright-stealth/local/prepare-publish.js
+++ b/experimental/playwright-stealth/local/prepare-publish.js
@@ -42,7 +42,10 @@ async function prepare() {
   // Now build the local package
   console.log('Building local package...');
   try {
-    execSync('npx --package typescript tsc && npx --package typescript tsc -p tsconfig.integration.json', { stdio: 'inherit' });
+    execSync(
+      'npx --package typescript tsc && npx --package typescript tsc -p tsconfig.integration.json',
+      { stdio: 'inherit' }
+    );
   } catch (e) {
     console.error('Failed to build local package:', e.message);
     process.exit(1);

--- a/experimental/playwright-stealth/local/prepare-publish.js
+++ b/experimental/playwright-stealth/local/prepare-publish.js
@@ -42,7 +42,7 @@ async function prepare() {
   // Now build the local package
   console.log('Building local package...');
   try {
-    execSync('npx tsc && npx tsc -p tsconfig.integration.json', { stdio: 'inherit' });
+    execSync('npx --package typescript tsc && npx --package typescript tsc -p tsconfig.integration.json', { stdio: 'inherit' });
   } catch (e) {
     console.error('Failed to build local package:', e.message);
     process.exit(1);

--- a/experimental/pointsyeah/local/prepare-publish.js
+++ b/experimental/pointsyeah/local/prepare-publish.js
@@ -41,7 +41,10 @@ async function prepare() {
   // Now build the local package
   console.log('Building local package...');
   try {
-    execSync('npx --package typescript tsc && npx --package typescript tsc -p tsconfig.integration.json', { stdio: 'inherit' });
+    execSync(
+      'npx --package typescript tsc && npx --package typescript tsc -p tsconfig.integration.json',
+      { stdio: 'inherit' }
+    );
   } catch (e) {
     console.error('Failed to build local package:', e.message);
     process.exit(1);

--- a/experimental/pointsyeah/local/prepare-publish.js
+++ b/experimental/pointsyeah/local/prepare-publish.js
@@ -41,7 +41,7 @@ async function prepare() {
   // Now build the local package
   console.log('Building local package...');
   try {
-    execSync('npx tsc && npx tsc -p tsconfig.integration.json', { stdio: 'inherit' });
+    execSync('npx --package typescript tsc && npx --package typescript tsc -p tsconfig.integration.json', { stdio: 'inherit' });
   } catch (e) {
     console.error('Failed to build local package:', e.message);
     process.exit(1);

--- a/experimental/proctor/local/prepare-publish.js
+++ b/experimental/proctor/local/prepare-publish.js
@@ -42,7 +42,10 @@ async function prepare() {
   // Now build the local package
   console.log('Building local package...');
   try {
-    execSync('npx --package typescript tsc && npx --package typescript tsc -p tsconfig.integration.json', { stdio: 'inherit' });
+    execSync(
+      'npx --package typescript tsc && npx --package typescript tsc -p tsconfig.integration.json',
+      { stdio: 'inherit' }
+    );
   } catch (e) {
     console.error('Failed to build local package:', e.message);
     process.exit(1);

--- a/experimental/proctor/local/prepare-publish.js
+++ b/experimental/proctor/local/prepare-publish.js
@@ -42,7 +42,7 @@ async function prepare() {
   // Now build the local package
   console.log('Building local package...');
   try {
-    execSync('npx tsc && npx tsc -p tsconfig.integration.json', { stdio: 'inherit' });
+    execSync('npx --package typescript tsc && npx --package typescript tsc -p tsconfig.integration.json', { stdio: 'inherit' });
   } catch (e) {
     console.error('Failed to build local package:', e.message);
     process.exit(1);

--- a/experimental/pulsemcp-cms-admin/local/prepare-publish.js
+++ b/experimental/pulsemcp-cms-admin/local/prepare-publish.js
@@ -42,7 +42,10 @@ async function prepare() {
   // Now build the local package
   console.log('Building local package...');
   try {
-    execSync('npx --package typescript tsc && npx --package typescript tsc -p tsconfig.integration.json', { stdio: 'inherit' });
+    execSync(
+      'npx --package typescript tsc && npx --package typescript tsc -p tsconfig.integration.json',
+      { stdio: 'inherit' }
+    );
   } catch (e) {
     console.error('Failed to build local package:', e.message);
     process.exit(1);

--- a/experimental/pulsemcp-cms-admin/local/prepare-publish.js
+++ b/experimental/pulsemcp-cms-admin/local/prepare-publish.js
@@ -42,7 +42,7 @@ async function prepare() {
   // Now build the local package
   console.log('Building local package...');
   try {
-    execSync('npx tsc && npx tsc -p tsconfig.integration.json', { stdio: 'inherit' });
+    execSync('npx --package typescript tsc && npx --package typescript tsc -p tsconfig.integration.json', { stdio: 'inherit' });
   } catch (e) {
     console.error('Failed to build local package:', e.message);
     process.exit(1);

--- a/experimental/remote-filesystem/local/prepare-publish.js
+++ b/experimental/remote-filesystem/local/prepare-publish.js
@@ -42,7 +42,10 @@ async function prepare() {
   // Now build the local package
   console.log('Building local package...');
   try {
-    execSync('npx --package typescript tsc && npx --package typescript tsc -p tsconfig.integration.json', { stdio: 'inherit' });
+    execSync(
+      'npx --package typescript tsc && npx --package typescript tsc -p tsconfig.integration.json',
+      { stdio: 'inherit' }
+    );
   } catch (e) {
     console.error('Failed to build local package:', e.message);
     process.exit(1);

--- a/experimental/remote-filesystem/local/prepare-publish.js
+++ b/experimental/remote-filesystem/local/prepare-publish.js
@@ -42,7 +42,7 @@ async function prepare() {
   // Now build the local package
   console.log('Building local package...');
   try {
-    execSync('npx tsc && npx tsc -p tsconfig.integration.json', { stdio: 'inherit' });
+    execSync('npx --package typescript tsc && npx --package typescript tsc -p tsconfig.integration.json', { stdio: 'inherit' });
   } catch (e) {
     console.error('Failed to build local package:', e.message);
     process.exit(1);

--- a/experimental/s3/local/prepare-publish.js
+++ b/experimental/s3/local/prepare-publish.js
@@ -42,7 +42,10 @@ async function prepare() {
   // Now build the local package
   console.log('Building local package...');
   try {
-    execSync('npx --package typescript tsc && npx --package typescript tsc -p tsconfig.integration.json', { stdio: 'inherit' });
+    execSync(
+      'npx --package typescript tsc && npx --package typescript tsc -p tsconfig.integration.json',
+      { stdio: 'inherit' }
+    );
   } catch (e) {
     console.error('Failed to build local package:', e.message);
     process.exit(1);

--- a/experimental/s3/local/prepare-publish.js
+++ b/experimental/s3/local/prepare-publish.js
@@ -42,7 +42,7 @@ async function prepare() {
   // Now build the local package
   console.log('Building local package...');
   try {
-    execSync('npx tsc && npx tsc -p tsconfig.integration.json', { stdio: 'inherit' });
+    execSync('npx --package typescript tsc && npx --package typescript tsc -p tsconfig.integration.json', { stdio: 'inherit' });
   } catch (e) {
     console.error('Failed to build local package:', e.message);
     process.exit(1);

--- a/experimental/serpapi-hotels/local/prepare-publish.js
+++ b/experimental/serpapi-hotels/local/prepare-publish.js
@@ -24,7 +24,7 @@ async function preparePublish() {
 
   // Step 4: Build local
   console.log('\n4. Building local module...');
-  execSync('npx tsc', { cwd: __dirname, stdio: 'inherit' });
+  execSync('npx --package typescript tsc', { cwd: __dirname, stdio: 'inherit' });
 
   // Step 5: Remove symlink and copy built shared files
   console.log('\n5. Preparing shared files for package...');

--- a/experimental/slack/local/prepare-publish.js
+++ b/experimental/slack/local/prepare-publish.js
@@ -28,7 +28,7 @@ async function preparePublish() {
   execSync('node setup-dev.js', { cwd: __dirname, stdio: 'inherit' });
 
   console.log('Building local module...');
-  execSync('npx tsc', { cwd: __dirname, stdio: 'inherit' });
+  execSync('npx --package typescript tsc', { cwd: __dirname, stdio: 'inherit' });
 
   // Remove symlink and copy actual files
   const sharedPath = join(__dirname, 'shared');

--- a/experimental/ssh/local/prepare-publish.js
+++ b/experimental/ssh/local/prepare-publish.js
@@ -42,7 +42,10 @@ async function prepare() {
   // Now build the local package
   console.log('Building local package...');
   try {
-    execSync('npx --package typescript tsc && npx --package typescript tsc -p tsconfig.integration.json', { stdio: 'inherit' });
+    execSync(
+      'npx --package typescript tsc && npx --package typescript tsc -p tsconfig.integration.json',
+      { stdio: 'inherit' }
+    );
   } catch (e) {
     console.error('Failed to build local package:', e.message);
     process.exit(1);

--- a/experimental/ssh/local/prepare-publish.js
+++ b/experimental/ssh/local/prepare-publish.js
@@ -42,7 +42,7 @@ async function prepare() {
   // Now build the local package
   console.log('Building local package...');
   try {
-    execSync('npx tsc && npx tsc -p tsconfig.integration.json', { stdio: 'inherit' });
+    execSync('npx --package typescript tsc && npx --package typescript tsc -p tsconfig.integration.json', { stdio: 'inherit' });
   } catch (e) {
     console.error('Failed to build local package:', e.message);
     process.exit(1);

--- a/experimental/twist/local/prepare-publish.js
+++ b/experimental/twist/local/prepare-publish.js
@@ -42,7 +42,10 @@ async function prepare() {
   // Now build the local package
   console.log('Building local package...');
   try {
-    execSync('npx --package typescript tsc && npx --package typescript tsc -p tsconfig.integration.json', { stdio: 'inherit' });
+    execSync(
+      'npx --package typescript tsc && npx --package typescript tsc -p tsconfig.integration.json',
+      { stdio: 'inherit' }
+    );
   } catch (e) {
     console.error('Failed to build local package:', e.message);
     process.exit(1);

--- a/experimental/twist/local/prepare-publish.js
+++ b/experimental/twist/local/prepare-publish.js
@@ -42,7 +42,7 @@ async function prepare() {
   // Now build the local package
   console.log('Building local package...');
   try {
-    execSync('npx tsc && npx tsc -p tsconfig.integration.json', { stdio: 'inherit' });
+    execSync('npx --package typescript tsc && npx --package typescript tsc -p tsconfig.integration.json', { stdio: 'inherit' });
   } catch (e) {
     console.error('Failed to build local package:', e.message);
     process.exit(1);

--- a/experimental/vercel/local/prepare-publish.js
+++ b/experimental/vercel/local/prepare-publish.js
@@ -42,7 +42,10 @@ async function prepare() {
   // Now build the local package
   console.log('Building local package...');
   try {
-    execSync('npx --package typescript tsc && npx --package typescript tsc -p tsconfig.integration.json', { stdio: 'inherit' });
+    execSync(
+      'npx --package typescript tsc && npx --package typescript tsc -p tsconfig.integration.json',
+      { stdio: 'inherit' }
+    );
   } catch (e) {
     console.error('Failed to build local package:', e.message);
     process.exit(1);

--- a/experimental/vercel/local/prepare-publish.js
+++ b/experimental/vercel/local/prepare-publish.js
@@ -42,7 +42,7 @@ async function prepare() {
   // Now build the local package
   console.log('Building local package...');
   try {
-    execSync('npx tsc && npx tsc -p tsconfig.integration.json', { stdio: 'inherit' });
+    execSync('npx --package typescript tsc && npx --package typescript tsc -p tsconfig.integration.json', { stdio: 'inherit' });
   } catch (e) {
     console.error('Failed to build local package:', e.message);
     process.exit(1);

--- a/libs/mcp-server-template/local/prepare-publish.js
+++ b/libs/mcp-server-template/local/prepare-publish.js
@@ -42,7 +42,10 @@ async function prepare() {
   // Now build the local package
   console.log('Building local package...');
   try {
-    execSync('npx --package typescript tsc && npx --package typescript tsc -p tsconfig.integration.json', { stdio: 'inherit' });
+    execSync(
+      'npx --package typescript tsc && npx --package typescript tsc -p tsconfig.integration.json',
+      { stdio: 'inherit' }
+    );
   } catch (e) {
     console.error('Failed to build local package:', e.message);
     process.exit(1);

--- a/libs/mcp-server-template/local/prepare-publish.js
+++ b/libs/mcp-server-template/local/prepare-publish.js
@@ -42,7 +42,7 @@ async function prepare() {
   // Now build the local package
   console.log('Building local package...');
   try {
-    execSync('npx tsc && npx tsc -p tsconfig.integration.json', { stdio: 'inherit' });
+    execSync('npx --package typescript tsc && npx --package typescript tsc -p tsconfig.integration.json', { stdio: 'inherit' });
   } catch (e) {
     console.error('Failed to build local package:', e.message);
     process.exit(1);

--- a/productionized/image-diff/local/prepare-publish.js
+++ b/productionized/image-diff/local/prepare-publish.js
@@ -37,7 +37,7 @@ async function prepare() {
 
   console.log('Building local package...');
   try {
-    execSync('npx tsc', { stdio: 'inherit' });
+    execSync('npx --package typescript tsc', { stdio: 'inherit' });
   } catch (e) {
     console.error('Failed to build local package:', e.message);
     process.exit(1);

--- a/productionized/pulse-fetch/local/prepare-publish.js
+++ b/productionized/pulse-fetch/local/prepare-publish.js
@@ -42,7 +42,10 @@ async function prepare() {
   // Now build the local package
   console.log('Building local package...');
   try {
-    execSync('npx --package typescript tsc && npx --package typescript tsc -p tsconfig.integration.json', { stdio: 'inherit' });
+    execSync(
+      'npx --package typescript tsc && npx --package typescript tsc -p tsconfig.integration.json',
+      { stdio: 'inherit' }
+    );
   } catch (e) {
     console.error('Failed to build local package:', e.message);
     process.exit(1);

--- a/productionized/pulse-fetch/local/prepare-publish.js
+++ b/productionized/pulse-fetch/local/prepare-publish.js
@@ -42,7 +42,7 @@ async function prepare() {
   // Now build the local package
   console.log('Building local package...');
   try {
-    execSync('npx tsc && npx tsc -p tsconfig.integration.json', { stdio: 'inherit' });
+    execSync('npx --package typescript tsc && npx --package typescript tsc -p tsconfig.integration.json', { stdio: 'inherit' });
   } catch (e) {
     console.error('Failed to build local package:', e.message);
     process.exit(1);

--- a/productionized/pulse-subregistry/local/prepare-publish.js
+++ b/productionized/pulse-subregistry/local/prepare-publish.js
@@ -42,7 +42,10 @@ async function prepare() {
   // Now build the local package
   console.log('Building local package...');
   try {
-    execSync('npx --package typescript tsc && npx --package typescript tsc -p tsconfig.integration.json', { stdio: 'inherit' });
+    execSync(
+      'npx --package typescript tsc && npx --package typescript tsc -p tsconfig.integration.json',
+      { stdio: 'inherit' }
+    );
   } catch (e) {
     console.error('Failed to build local package:', e.message);
     process.exit(1);

--- a/productionized/pulse-subregistry/local/prepare-publish.js
+++ b/productionized/pulse-subregistry/local/prepare-publish.js
@@ -42,7 +42,7 @@ async function prepare() {
   // Now build the local package
   console.log('Building local package...');
   try {
-    execSync('npx tsc && npx tsc -p tsconfig.integration.json', { stdio: 'inherit' });
+    execSync('npx --package typescript tsc && npx --package typescript tsc -p tsconfig.integration.json', { stdio: 'inherit' });
   } catch (e) {
     console.error('Failed to build local package:', e.message);
     process.exit(1);

--- a/productionized/svg-tracer/local/prepare-publish.js
+++ b/productionized/svg-tracer/local/prepare-publish.js
@@ -41,7 +41,10 @@ async function prepare() {
   // Now build the local package
   console.log('Building local package...');
   try {
-    execSync('npx --package typescript tsc && npx --package typescript tsc -p tsconfig.integration.json', { stdio: 'inherit' });
+    execSync(
+      'npx --package typescript tsc && npx --package typescript tsc -p tsconfig.integration.json',
+      { stdio: 'inherit' }
+    );
   } catch (e) {
     console.error('Failed to build local package:', e.message);
     process.exit(1);

--- a/productionized/svg-tracer/local/prepare-publish.js
+++ b/productionized/svg-tracer/local/prepare-publish.js
@@ -41,7 +41,7 @@ async function prepare() {
   // Now build the local package
   console.log('Building local package...');
   try {
-    execSync('npx tsc && npx tsc -p tsconfig.integration.json', { stdio: 'inherit' });
+    execSync('npx --package typescript tsc && npx --package typescript tsc -p tsconfig.integration.json', { stdio: 'inherit' });
   } catch (e) {
     console.error('Failed to build local package:', e.message);
     process.exit(1);


### PR DESCRIPTION
## Summary

Two fixes for the CI/distribution pipeline observed on PR #537:

**Issue 1 — Auto-merge ignores verify-publications failures:** The `ci-build-test-checks.yml` aggregator workflow filters checks by name, monitoring only checks containing "MCP Server" plus `Lint & Type Check` and `Validate Publish Files`. The `verify-publications` check was NOT in this filter. Since `CI Build & Test Checks Passed` is the required status check for merge, auto-merge proceeded as soon as it passed — even though `verify-publications` had failed. Fixed by adding `verify-publications` to both filter expressions in the aggregator.

**Issue 2 — `npx tsc` resolves to wrong npm package:** All 30 `prepare-publish.js` files used `npx tsc` to compile TypeScript. When the `tsc` binary isn't found in the local `node_modules/.bin/`, `npx` falls back to downloading from npm — and finds the unrelated [`tsc@2.0.4`](https://www.npmjs.com/package/tsc) package instead of TypeScript's compiler. This caused the publish dry-run to fail on PR #537 with:
```
npm warn exec The following package was not found and will be installed: tsc@2.0.4
npm error code ENOENT
```
Fixed by replacing `npx tsc` with `npx --package typescript tsc` in all 30 files, which explicitly tells npx to source the binary from the `typescript` package.

## Verification

- [x] **Root cause confirmed via CI logs:** `gh run view 24323807988 --log-failed` shows `tsc@2.0.4` being installed and immediately failing with ENOENT — the wrong package was downloaded
- [x] **Aggregator gap confirmed:** The filter `run.name.includes('MCP Server') || run.name === 'Lint & Type Check' || run.name === 'Validate Publish Files'` does not match `verify-publications`, so the aggregator passed while verify-publications failed
- [x] **PR #537 timeline confirms the race:** auto-merge was enabled at 03:08:56Z, verify-publications failed at 03:09:24Z, the aggregator passed at 03:10:35Z, and merge happened at 03:10:37Z — 2 seconds after the aggregator passed, completely ignoring the earlier failure
- [x] **Both filter locations updated:** The aggregator has two filter expressions (polling loop and final check) — both now include `verify-publications`
- [x] **All 30 prepare-publish.js files updated consistently:** Grep confirms zero remaining bare `npx tsc` calls
- [x] **Pre-commit hooks passed:** Prettier formatted the YAML file; commit succeeded cleanly
- [x] Self-reviewed PR diff — no unintended changes