### PR TITLE
Remove manual test CI gating from verify-publications workflow

### DIFF
--- a/.github/workflows/verify-mcp-server-publication.yml
+++ b/.github/workflows/verify-mcp-server-publication.yml
@@ -18,12 +18,6 @@ jobs:
         with:
           fetch-depth: 0 # Need full history to check for version changes
 
-      - name: Fetch PR branch
-        run: |
-          git fetch origin pull/${{ github.event.pull_request.number }}/head:pr-branch
-          echo "PR branch commits:"
-          git log --oneline pr-branch | head -20
-
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
@@ -175,73 +169,6 @@ jobs:
               fi
             else
               echo "ℹ️  Skipping CHANGELOG/README checks - no version bump"
-            fi
-            
-            # Check for manual test results if version was bumped
-            if [ "$VERSION_BUMPED" = true ]; then
-              MANUAL_TESTING_FILE="$SERVER_DIR/MANUAL_TESTING.md"
-              if [ -f "$MANUAL_TESTING_FILE" ]; then
-                echo "Checking manual test results..."
-                
-                # Get the commit hash from the PR
-                PR_COMMIT="${{ github.event.pull_request.head.sha }}"
-                PR_COMMIT_SHORT="${PR_COMMIT:0:7}"
-                
-                # Check if MANUAL_TESTING.md contains test results for a recent commit
-                if grep -q "^\*\*Commit:" "$MANUAL_TESTING_FILE"; then
-                  # Extract the commit hash from the file
-                  TESTED_COMMIT=$(grep "^\*\*Commit:" "$MANUAL_TESTING_FILE" | sed 's/^\*\*Commit:\*\* *//' | cut -d' ' -f1)
-                  TESTED_COMMIT_SHORT="${TESTED_COMMIT:0:7}"
-                  
-                  echo "Manual tests were run on commit: $TESTED_COMMIT_SHORT"
-                  
-                  # Check if the tested commit is in the PR's commit history
-                  # First, try to check if the commit exists in the current git history
-                  COMMIT_FOUND_IN_PR=false
-                  
-                  # Check if the tested commit exists and is in the PR branch
-                  if git rev-list pr-branch | grep -q "^${TESTED_COMMIT}"; then
-                    echo "✅ Manual tests were run on a commit in this PR's history"
-                    COMMIT_FOUND_IN_PR=true
-                  else
-                    # Fallback: check with short SHA
-                    if git rev-list pr-branch | grep -q "^${TESTED_COMMIT_SHORT}"; then
-                      echo "✅ Manual tests were run on a commit in this PR's history"
-                      COMMIT_FOUND_IN_PR=true
-                    else
-                      echo "❌ ERROR: Manual tests were run on commit $TESTED_COMMIT_SHORT"
-                      echo "   This commit is not in the current PR's history"
-                      echo "   Available commits in PR:"
-                      git log --oneline pr-branch | head -10
-                      echo ""
-                      echo "   🚨 IMPORTANT: Update the commit reference in the 'Latest Test Results' section"
-                      echo "   This script checks the FIRST **Commit:** line in MANUAL_TESTING.md (around line 9)"
-                      echo "   NOT the one in the 'Manual Test Results' section at the bottom of the file"
-                      echo ""
-                      echo "   To fix: Update the **Commit:** field in the 'Latest Test Results' section to reference"
-                      echo "   ANY existing commit from the PR history shown above (pick any commit hash from the list)"
-                      VERIFICATION_FAILED=true
-                    fi
-                  fi
-                  
-                  # Check test results if commit was found
-                  if [ "$COMMIT_FOUND_IN_PR" = true ]; then
-                    # Check test results (but don't fail if tests didn't pass)
-                    if grep -q "**Overall:**.* 100%" "$MANUAL_TESTING_FILE" || grep -q "All manual tests passed" "$MANUAL_TESTING_FILE"; then
-                      echo "✅ Manual tests passed"
-                    else
-                      echo "ℹ️  Manual tests did not achieve 100% pass rate"
-                      echo "   Review MANUAL_TESTING.md for details"
-                    fi
-                  fi
-                else
-                  echo "❌ ERROR: MANUAL_TESTING.md exists but doesn't contain test results"
-                  echo "   Please run manual tests and document the results"
-                  VERIFICATION_FAILED=true
-                fi
-              else
-                echo "ℹ️  No MANUAL_TESTING.md found - manual tests may not be applicable"
-              fi
             fi
             
             # Run tests for this server

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,6 +146,7 @@ npm run lint       # Check for linting issues
 npm run lint:fix   # Auto-fix linting issues
 npm run format     # Format code with Prettier
 npm test           # Run tests (functional and/or integration)
+npm run test:manual # Run manual tests (if available - hits real APIs)
 ```
 
 ### Linting Best Practices
@@ -180,7 +181,7 @@ cd experimental/twist && prettier --write .
 - **Core Dependencies**: `@modelcontextprotocol/sdk`, `zod`
 - **Build Tool**: TypeScript compiler (tsc)
 - **Dev Tool**: tsx for development mode
-- **Testing**: Vitest for unit and integration tests
+- **Testing**: Vitest for unit, integration, and manual tests
 
 ## Dependency Management
 
@@ -271,10 +272,17 @@ npm run build                         # Builds both shared and local
 
 Running full test suites locally is prone to failure. Instead, run only targeted tests for the files you changed, then commit to a PR and let CI run the complete test suite.
 
-MCP servers may include up to two types of tests:
+MCP servers may include up to three types of tests:
 
 1. **Functional Tests** - Unit tests with all dependencies mocked
 2. **Integration Tests** - Tests using TestMCPClient with mocked external APIs
+3. **Manual Tests** - Tests that hit real external APIs (not run in CI)
+
+Manual tests are particularly important when:
+
+- Modifying code that interacts with external APIs
+- Debugging issues that only appear with real API responses
+- Verifying that API integrations work correctly
 
 To run targeted tests locally:
 
@@ -289,7 +297,40 @@ cd experimental/twist && npx vitest run tests/specific.test.ts
 # Instead, commit to a PR and let CI run the full test suite
 ```
 
+To run manual tests (when available):
+
+```bash
+# IMPORTANT: Use .env files in the MCP server's source root for API keys
+cd /to/mcp-server
+less .env # Confirm it's there
+
+# Run manual tests
+npm run test:manual
+```
+
 **Note**: Always use `.env` files in the MCP server's source root to store API keys and credentials. Never commit these files to version control.
+
+**CRITICAL: Manual tests MUST run against staging, not production.** For servers that connect to PulseMCP APIs (like `pulsemcp-cms-admin`), always set `PULSEMCP_ADMIN_API_URL=https://admin.staging.pulsemcp.com` in the `.env` file. The default API URL is production — running manual tests without the staging URL will either fail with "Invalid API key" (if using a staging key) or mutate production data (if using a production key). Check each server's `.env.example` for the required variables.
+
+**CRITICAL: If the `.env` file is missing or doesn't contain the required API keys/credentials, STOP and ask the user to provide them.** Do NOT silently skip manual tests or proceed without credentials. Check for the `.env` file BEFORE attempting to run manual tests — if it's missing or looks incomplete, ask the user for the required credentials immediately.
+
+### CRITICAL: Manual Test Integrity Policy
+
+**Manual tests MUST actually test real functionality against real APIs. No exceptions.**
+
+- **NEVER** write manual tests that skip, bypass, or gracefully handle missing backend functionality
+- **NEVER** use patterns like `if (response.includes('404')) { return; }` to silently pass when an endpoint doesn't exist
+- **NEVER** implement client-side code for API endpoints that don't exist yet, then write "tests" that skip when the endpoint returns 404
+- If a backend API endpoint doesn't exist, **DO NOT** write the client code until the backend is ready
+- Manual tests exist to verify that real integrations work - a test that skips on failure defeats the entire purpose
+
+**If you find yourself writing a manual test that needs to "gracefully handle" a missing endpoint:**
+
+1. STOP - you are doing it wrong
+2. The backend endpoint must exist and be functional BEFORE you write client code for it
+3. Coordinate with the backend team first, get the endpoint deployed, THEN implement the client
+
+**Why this matters:** A merged PR with "passing" manual tests that actually skip broken functionality gives false confidence. It results in shipped code that doesn't work, discovered only when users try to use it.
 
 ## Versioning and Release Workflow
 
@@ -303,6 +344,18 @@ Patch version bumps are cheap and low-risk — ship them as soon as you have con
 - Update the CHANGELOG.md to move the change from "Unreleased" into the new version entry
 - Commit the version bump alongside your code changes in the same PR
 - Do NOT leave changes sitting in an "Unreleased" changelog section waiting for a separate release PR
+
+### Manual Testing for Significant Features (Minor+ Version Changes)
+
+**Whenever adding a significant feature — anything that warrants at least a minor version bump — you MUST run the manual testing suite before considering the task complete.**
+
+Manual tests often require secrets/credentials (API keys, tokens, etc.) that the agent won't have access to. When this happens:
+
+1. **Prompt the user for any required secrets/credentials** needed to run the manual tests. Check the server's `.env.example` or test files to identify what's needed, then ask the user to provide them
+2. **Actually run through the manual testing steps** (`npm run test:manual`) — do not skip this step
+3. **Do not skip manual testing just because it requires user interaction** — ask for what you need and wait for the user to provide it
+
+This applies to minor and major version bumps. For patch-level changes (small bug fixes, minor tweaks), manual testing is encouraged but not strictly required — use your judgment based on the risk of the change.
 
 ## Creating New Servers
 
@@ -403,8 +456,21 @@ Don't add: basic TypeScript fixes, standard npm troubleshooting, obvious file op
 - Breaking changes in tool parameters should be clearly marked in CHANGELOG.md with **BREAKING** prefix to alert users
 - When using `set -e` in shell scripts with npm commands, be aware that `npm view` returns exit code 1 when a package doesn't exist yet - use `|| true` to prevent premature script termination during npm registry propagation checks
 - **For `/publish-and-pr` skill**: This means "stage for publishing and update PR" - it does NOT mean actually publish to npm. The workflow is: bump version → update changelog → commit → push → update PR. NPM publishing happens automatically via CI when PR is merged
+- **Manual Testing Before Publishing**: Always run manual tests (with real API credentials) before staging a version bump to ensure the server works correctly with external APIs. If the `.env` file with credentials is missing, STOP and ask the user to provide them — do NOT skip manual tests
 - **Git Tag Format for Version Bumps**: When creating git tags for version bumps, use the format `package-name@version` (e.g., `appsignal-mcp-server@0.2.12`, `@pulsemcp/pulse-fetch@0.2.10`). The CI verify-publications workflow expects this exact format, not `server-name-vX.Y.Z`
 - **npm Package Files Field**: When specifying files to include in npm packages, use specific glob patterns (e.g., `"build/**/*.js"`) rather than entire directories (e.g., `"build/"`) to ensure proper file permissions and avoid including non-executable files. This prevents "Permission denied" errors when users run the package with npx
+
+### Manual Testing Infrastructure
+
+- Manual test files typically live in `tests/manual/` and use `.manual.test.ts` extension
+- **First-time setup for new worktrees**: Always run `npm run test:manual:setup` before running manual tests in a fresh checkout or new worktree. This ensures all dependencies are installed, the project is built, and test-mcp-client is available
+- **Always use `npm run test:manual` to run manual tests** - this script handles building, vitest configuration, and proper ESM support automatically. Don't try to run vitest directly or manually build the project first
+- To run manual tests with proper ESM support, create a `scripts/run-vitest.js` wrapper that imports vitest's CLI directly
+- When setting up manual tests for servers with workspace structures (local/shared), ensure dependencies are properly installed in all subdirectories before running tests
+- Manual tests should run against built code (not source) - create a `run-manual-built.js` script that builds the project first, then runs tests against the compiled JavaScript
+- **Manual test setup checklist**: Verify .env exists with real API keys, run `ci:install` to install all workspace dependencies, run `build:test` to build everything including test-mcp-client
+- **CRITICAL: Missing credentials policy**: If the `.env` file is missing or doesn't contain the required API keys/credentials for manual tests, STOP and ask the user to provide them. Do NOT silently skip manual tests or proceed without credentials. Agents must check for `.env` BEFORE running manual tests and prompt the user if it's missing or incomplete
+- **CRITICAL: Manual tests must actually pass against real APIs** - NEVER write tests that skip or gracefully handle missing backend endpoints. If an API endpoint doesn't exist, do not write client code for it. A "passing" test that silently skips on 404 is worse than no test at all because it provides false confidence
 
 ### Monorepo Dependency Management
 
@@ -434,7 +500,7 @@ Whenever you make any sort of code change to an MCP server, make sure to update 
 ### Test Infrastructure Patterns
 
 - **Memory Storage URI Collisions**: Memory storage implementations that generate URIs using timestamp-based schemes must account for rapid test execution. Using millisecond timestamps with stripped characters can cause collisions in fast CI environments - use 10ms+ delays between writes in tests
-- **External Service Timeouts**: When integration tests encounter external service timeouts (like Firecrawl API), prioritize testing core functionality (native strategies, content parsing) over external service reliability. Network timeouts don't indicate code problems
+- **External Service Timeouts**: When manual tests encounter external service timeouts (like Firecrawl API), prioritize testing core functionality (native strategies, content parsing) over external service reliability. Network timeouts don't indicate code problems
 
 ### Version Bump and Publication Workflow
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,7 +146,6 @@ npm run lint       # Check for linting issues
 npm run lint:fix   # Auto-fix linting issues
 npm run format     # Format code with Prettier
 npm test           # Run tests (functional and/or integration)
-npm run test:manual # Run manual tests (if available - hits real APIs)
 ```
 
 ### Linting Best Practices
@@ -181,7 +180,7 @@ cd experimental/twist && prettier --write .
 - **Core Dependencies**: `@modelcontextprotocol/sdk`, `zod`
 - **Build Tool**: TypeScript compiler (tsc)
 - **Dev Tool**: tsx for development mode
-- **Testing**: Vitest for unit, integration, and manual tests
+- **Testing**: Vitest for unit and integration tests
 
 ## Dependency Management
 
@@ -272,17 +271,10 @@ npm run build                         # Builds both shared and local
 
 Running full test suites locally is prone to failure. Instead, run only targeted tests for the files you changed, then commit to a PR and let CI run the complete test suite.
 
-MCP servers may include up to three types of tests:
+MCP servers may include up to two types of tests:
 
 1. **Functional Tests** - Unit tests with all dependencies mocked
 2. **Integration Tests** - Tests using TestMCPClient with mocked external APIs
-3. **Manual Tests** - Tests that hit real external APIs (not run in CI)
-
-Manual tests are particularly important when:
-
-- Modifying code that interacts with external APIs
-- Debugging issues that only appear with real API responses
-- Verifying that API integrations work correctly
 
 To run targeted tests locally:
 
@@ -297,40 +289,7 @@ cd experimental/twist && npx vitest run tests/specific.test.ts
 # Instead, commit to a PR and let CI run the full test suite
 ```
 
-To run manual tests (when available):
-
-```bash
-# IMPORTANT: Use .env files in the MCP server's source root for API keys
-cd /to/mcp-server
-less .env # Confirm it's there
-
-# Run manual tests
-npm run test:manual
-```
-
 **Note**: Always use `.env` files in the MCP server's source root to store API keys and credentials. Never commit these files to version control.
-
-**CRITICAL: Manual tests MUST run against staging, not production.** For servers that connect to PulseMCP APIs (like `pulsemcp-cms-admin`), always set `PULSEMCP_ADMIN_API_URL=https://admin.staging.pulsemcp.com` in the `.env` file. The default API URL is production — running manual tests without the staging URL will either fail with "Invalid API key" (if using a staging key) or mutate production data (if using a production key). Check each server's `.env.example` for the required variables.
-
-**CRITICAL: If the `.env` file is missing or doesn't contain the required API keys/credentials, STOP and ask the user to provide them.** Do NOT silently skip manual tests or proceed without credentials. Check for the `.env` file BEFORE attempting to run manual tests — if it's missing or looks incomplete, ask the user for the required credentials immediately.
-
-### CRITICAL: Manual Test Integrity Policy
-
-**Manual tests MUST actually test real functionality against real APIs. No exceptions.**
-
-- **NEVER** write manual tests that skip, bypass, or gracefully handle missing backend functionality
-- **NEVER** use patterns like `if (response.includes('404')) { return; }` to silently pass when an endpoint doesn't exist
-- **NEVER** implement client-side code for API endpoints that don't exist yet, then write "tests" that skip when the endpoint returns 404
-- If a backend API endpoint doesn't exist, **DO NOT** write the client code until the backend is ready
-- Manual tests exist to verify that real integrations work - a test that skips on failure defeats the entire purpose
-
-**If you find yourself writing a manual test that needs to "gracefully handle" a missing endpoint:**
-
-1. STOP - you are doing it wrong
-2. The backend endpoint must exist and be functional BEFORE you write client code for it
-3. Coordinate with the backend team first, get the endpoint deployed, THEN implement the client
-
-**Why this matters:** A merged PR with "passing" manual tests that actually skip broken functionality gives false confidence. It results in shipped code that doesn't work, discovered only when users try to use it.
 
 ## Versioning and Release Workflow
 
@@ -344,19 +303,6 @@ Patch version bumps are cheap and low-risk — ship them as soon as you have con
 - Update the CHANGELOG.md to move the change from "Unreleased" into the new version entry
 - Commit the version bump alongside your code changes in the same PR
 - Do NOT leave changes sitting in an "Unreleased" changelog section waiting for a separate release PR
-
-### Manual Testing for Significant Features (Minor+ Version Changes)
-
-**Whenever adding a significant feature — anything that warrants at least a minor version bump — you MUST run the manual testing suite before considering the task complete.**
-
-Manual tests often require secrets/credentials (API keys, tokens, etc.) that the agent won't have access to. When this happens:
-
-1. **Prompt the user for any required secrets/credentials** needed to run the manual tests. Check the server's `.env.example` or test files to identify what's needed, then ask the user to provide them
-2. **Actually run through the manual testing steps** (`npm run test:manual`) — do not skip this step
-3. **Do not skip manual testing just because it requires user interaction** — ask for what you need and wait for the user to provide it
-4. Update `MANUAL_TESTING.md` with the results before staging the version bump
-
-This applies to minor and major version bumps. For patch-level changes (small bug fixes, minor tweaks), manual testing is encouraged but not strictly required — use your judgment based on the risk of the change.
 
 ## Creating New Servers
 
@@ -457,25 +403,8 @@ Don't add: basic TypeScript fixes, standard npm troubleshooting, obvious file op
 - Breaking changes in tool parameters should be clearly marked in CHANGELOG.md with **BREAKING** prefix to alert users
 - When using `set -e` in shell scripts with npm commands, be aware that `npm view` returns exit code 1 when a package doesn't exist yet - use `|| true` to prevent premature script termination during npm registry propagation checks
 - **For `/publish-and-pr` skill**: This means "stage for publishing and update PR" - it does NOT mean actually publish to npm. The workflow is: bump version → update changelog → commit → push → update PR. NPM publishing happens automatically via CI when PR is merged
-- **Manual Testing Before Publishing**: Always run manual tests (with real API credentials) before staging a version bump to ensure the server works correctly with external APIs. If the `.env` file with credentials is missing, STOP and ask the user to provide them — do NOT skip manual tests
 - **Git Tag Format for Version Bumps**: When creating git tags for version bumps, use the format `package-name@version` (e.g., `appsignal-mcp-server@0.2.12`, `@pulsemcp/pulse-fetch@0.2.10`). The CI verify-publications workflow expects this exact format, not `server-name-vX.Y.Z`
-- **Manual Testing and CI**: The verify-publications CI check requires that MANUAL_TESTING.md references a commit that's in the PR's history. If you make any commits after running manual tests (even just test fixes), the CI will fail. For test-only fixes, this is a known limitation that doesn't require re-running manual tests. When updating MANUAL_TESTING.md for packaging-only changes, ensure the commit hash matches a commit in the current PR branch
 - **npm Package Files Field**: When specifying files to include in npm packages, use specific glob patterns (e.g., `"build/**/*.js"`) rather than entire directories (e.g., `"build/"`) to ensure proper file permissions and avoid including non-executable files. This prevents "Permission denied" errors when users run the package with npx
-
-### Manual Testing Infrastructure
-
-- All MCP servers should have a `MANUAL_TESTING.md` file to track manual test results
-- Manual test files typically live in `tests/manual/` and use `.manual.test.ts` extension
-- **First-time setup for new worktrees**: Always run `npm run test:manual:setup` before running manual tests in a fresh checkout or new worktree. This ensures all dependencies are installed, the project is built, and test-mcp-client is available
-- **Always use `npm run test:manual` to run manual tests** - this script handles building, vitest configuration, and proper ESM support automatically. Don't try to run vitest directly or manually build the project first
-- To run manual tests with proper ESM support, create a `scripts/run-vitest.js` wrapper that imports vitest's CLI directly
-- The CI workflow `verify-mcp-server-publication.yml` checks for manual test results when version bumps occur - it verifies tests were run on a commit in the PR's history and checks for passing results
-- When setting up manual tests for servers with workspace structures (local/shared), ensure dependencies are properly installed in all subdirectories before running tests
-- Manual tests should run against built code (not source) - create a `run-manual-built.js` script that builds the project first, then runs tests against the compiled JavaScript
-- CI should fail when MANUAL_TESTING.md isn't updated for the current PR, but NOT when tests fail (some failures might be expected due to API limitations)
-- **Manual test setup checklist**: Verify .env exists with real API keys, run `ci:install` to install all workspace dependencies, run `build:test` to build everything including test-mcp-client
-- **CRITICAL: Missing credentials policy**: If the `.env` file is missing or doesn't contain the required API keys/credentials for manual tests, STOP and ask the user to provide them. Do NOT silently skip manual tests or proceed without credentials. Agents must check for `.env` BEFORE running manual tests and prompt the user if it's missing or incomplete
-- **CRITICAL: Manual tests must actually pass against real APIs** - NEVER write tests that skip or gracefully handle missing backend endpoints. If an API endpoint doesn't exist, do not write client code for it. A "passing" test that silently skips on 404 is worse than no test at all because it provides false confidence
 
 ### Monorepo Dependency Management
 
@@ -505,12 +434,11 @@ Whenever you make any sort of code change to an MCP server, make sure to update 
 ### Test Infrastructure Patterns
 
 - **Memory Storage URI Collisions**: Memory storage implementations that generate URIs using timestamp-based schemes must account for rapid test execution. Using millisecond timestamps with stripped characters can cause collisions in fast CI environments - use 10ms+ delays between writes in tests
-- **External Service Timeouts**: When manual tests encounter external service timeouts (like Firecrawl API), prioritize testing core functionality (native strategies, content parsing) over external service reliability. Network timeouts don't indicate code problems
-- **Manual Test Result Documentation**: Always update MANUAL_TESTING.md with specific test results including: commit hash, test percentages, key functionality verified, and known external service issues. This provides CI verification and historical context
+- **External Service Timeouts**: When integration tests encounter external service timeouts (like Firecrawl API), prioritize testing core functionality (native strategies, content parsing) over external service reliability. Network timeouts don't indicate code problems
 
 ### Version Bump and Publication Workflow
 
-- **File Staging for Version Bumps**: The `npm run stage-publish` command modifies multiple files that MUST be committed together: local/package.json, parent/package-lock.json, CHANGELOG.md, README.md, and MANUAL_TESTING.md. Never commit these files separately or CI will fail
+- **File Staging for Version Bumps**: The `npm run stage-publish` command modifies multiple files that MUST be committed together: local/package.json, parent/package-lock.json, CHANGELOG.md, and README.md. Never commit these files separately or CI will fail
 - **Changelog Language Precision**: Avoid language like "restored" or "fixed" in changelogs when describing functionality that was developed within the same PR. Use accurate language like "added" or "implemented" to reflect what actually happened
 - **Dependency Consistency in Monorepos**: When adding production dependencies, ensure they exist in both shared/package.json AND local/package.json for proper publishing. Dependencies only in the root package.json won't be available in published packages
 
@@ -523,4 +451,4 @@ Whenever you make any sort of code change to an MCP server, make sure to update 
 ### Pre-commit Hook and Version Bump Workflow
 
 - **Lint-staged Automatic Stash Behavior**: When pre-commit hooks fail, lint-staged automatically stashes your changes. These can be recovered using `git stash list` and looking for "lint-staged automatic backup" entries. Apply with `git stash apply stash@{n}`
-- **Version Bump Recovery**: If `npm run stage-publish` fails or gets interrupted, changes may be partially applied. Check all expected files (local/package.json, CHANGELOG.md, MANUAL_TESTING.md, README.md) and re-run the version bump with `npm version patch --no-git-tag-version` if needed
+- **Version Bump Recovery**: If `npm run stage-publish` fails or gets interrupted, changes may be partially applied. Check all expected files (local/package.json, CHANGELOG.md, README.md) and re-run the version bump with `npm version patch --no-git-tag-version` if needed

--- a/docs/PUBLISHING_SERVERS.md
+++ b/docs/PUBLISHING_SERVERS.md
@@ -44,19 +44,6 @@ After staging the publication, update the server's CHANGELOG.md file:
 4. Add the version number and date
 5. Follow the [Keep a Changelog](https://keepachangelog.com) format
 
-### 2a. Run Manual Tests (If Applicable)
-
-For servers with manual tests (that require real API credentials):
-
-1. **Check for credentials first**: Verify that the `.env` file exists in the MCP server's source root and contains the required API keys. **If the `.env` file is missing or doesn't have the required credentials, STOP and ask the user to provide them. Do NOT skip manual tests or proceed without credentials.**
-2. Run the manual tests (automatically builds and tests):
-   ```bash
-   npm run test:manual
-   ```
-3. Update `MANUAL_TESTING.md` with the test results (overwrite previous results)
-4. Include commit hash, test date/time in PT, and results summary
-5. Use real API credentials from .env for proper testing
-
 Example:
 
 ```markdown
@@ -91,7 +78,6 @@ gh pr create --title "Publish appsignal-mcp-server@0.1.1" \
 - [x] Version bumped in package.json
 - [x] CHANGELOG.md updated
 - [x] All tests passing
-- [x] Manual tests run and MANUAL_TESTING.md updated (if applicable)
 - [x] Git tag created"
 ```
 
@@ -155,7 +141,6 @@ Before creating a PR:
 - [ ] Version bumped using `npm run stage-publish`
 - [ ] CHANGELOG.md updated with new version section
 - [ ] All tests pass (`npm test`, `npm run test:integration`)
-- [ ] Manual tests run and results updated in MANUAL_TESTING.md (if applicable — if `.env` credentials are missing, ask the user for them; do NOT skip)
 - [ ] Build succeeds (`npm run build`)
 - [ ] No sensitive information in code
 - [ ] Git tag created and pushed

--- a/docs/PUBLISHING_SERVERS.md
+++ b/docs/PUBLISHING_SERVERS.md
@@ -44,6 +44,16 @@ After staging the publication, update the server's CHANGELOG.md file:
 4. Add the version number and date
 5. Follow the [Keep a Changelog](https://keepachangelog.com) format
 
+### 2a. Run Manual Tests (If Applicable)
+
+For servers with manual tests (that require real API credentials):
+
+1. **Check for credentials first**: Verify that the `.env` file exists in the MCP server's source root and contains the required API keys. **If the `.env` file is missing or doesn't have the required credentials, STOP and ask the user to provide them. Do NOT skip manual tests or proceed without credentials.**
+2. Run the manual tests (automatically builds and tests):
+   ```bash
+   npm run test:manual
+   ```
+
 Example:
 
 ```markdown
@@ -78,6 +88,7 @@ gh pr create --title "Publish appsignal-mcp-server@0.1.1" \
 - [x] Version bumped in package.json
 - [x] CHANGELOG.md updated
 - [x] All tests passing
+- [x] Manual tests run (if applicable)
 - [x] Git tag created"
 ```
 
@@ -141,6 +152,7 @@ Before creating a PR:
 - [ ] Version bumped using `npm run stage-publish`
 - [ ] CHANGELOG.md updated with new version section
 - [ ] All tests pass (`npm test`, `npm run test:integration`)
+- [ ] Manual tests run (if applicable — if `.env` credentials are missing, ask the user for them; do NOT skip)
 - [ ] Build succeeds (`npm run build`)
 - [ ] No sensitive information in code
 - [ ] Git tag created and pushed

--- a/libs/mcp-server-template/MANUAL_TESTING.md
+++ b/libs/mcp-server-template/MANUAL_TESTING.md
@@ -144,14 +144,3 @@ Example:
 - 2025-01-10: Discovered pagination bug when offset > total count
 -->
 
----
-
-## CI Verification
-
-This file is checked by CI during version bumps. The CI workflow verifies:
-
-1. Manual tests were run on a commit in the PR's history
-2. The commit hash in this file matches a commit in the PR
-3. Tests show passing results
-
-**Important:** Always update this file after running manual tests and before creating a version bump.

--- a/libs/mcp-server-template/MANUAL_TESTING.md
+++ b/libs/mcp-server-template/MANUAL_TESTING.md
@@ -143,4 +143,3 @@ Example:
 - 2025-01-15: API rate limits caused intermittent failures - added retry logic
 - 2025-01-10: Discovered pagination bug when offset > total count
 -->
-


### PR DESCRIPTION
## Summary

Manual tests still exist and can be run manually, but CI no longer gates on their results. This PR removes the CI enforcement while preserving all manual test documentation.

### CI workflow changes (`verify-mcp-server-publication.yml`)
- Removed the block that checked `MANUAL_TESTING.md` for test results when a version bump was detected — this previously failed the workflow if the file didn't contain results or if the tested commit wasn't in the PR's history
- Removed the `Fetch PR branch` step that was solely used for manual test commit verification

### Documentation cleanup (CI gating references only)
- **CLAUDE.md**: Removed the "Manual Testing and CI" learning (CI requiring MANUAL_TESTING.md commit hashes), removed MANUAL_TESTING.md from CI file staging lists and version bump recovery lists. All other manual test documentation preserved (run instructions, integrity policy, infrastructure docs, credentials policy, publishing checklist)
- **docs/PUBLISHING_SERVERS.md**: Removed the step to "Update MANUAL_TESTING.md with test results" (was CI-enforced). Kept manual test run instructions and checklist items
- **libs/mcp-server-template/MANUAL_TESTING.md**: Removed the "CI Verification" section that claimed CI checks this file during version bumps

The rest of the verify-publications workflow is preserved: version bump detection, CHANGELOG validation, README version checks, git tag verification, build/test runs, and publish dry-runs all remain intact.

## Verification
- [x] Self-reviewed the diff — workflow changes are precisely scoped to the manual test gating block and unused PR branch fetch step; no other verification logic was touched
- [x] Grepped `.github/` directory for `MANUAL_TESTING`, `manual.test`, `manual_test` references — confirmed all CI gating references are removed from workflow files
- [x] Grepped CLAUDE.md for CI-specific manual test references — confirmed all removed (no matches for "CI.*MANUAL_TESTING", "verify-publications.*manual", etc.)
- [x] Verified manual test documentation is preserved: run instructions, integrity policy, infrastructure section, credentials policy, and publishing checklist items all still present in CLAUDE.md and PUBLISHING_SERVERS.md
- [x] E2E: CI passed green on all commits (all 3 checks: Lint & Type Check, Validate Publish Files, CI Build & Test Checks Passed) confirming the remaining checks still work without the manual test gate
- [x] Two rounds of subagent PR review completed — first round identified stale CLAUDE.md/PUBLISHING_SERVERS.md references (addressed), second round identified stale template MANUAL_TESTING.md CI section (addressed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)