### PR TITLE
Sync 1 servers from monorepo

### DIFF
--- a/.github/workflows/appsignal-ci.yml
+++ b/.github/workflows/appsignal-ci.yml
@@ -16,6 +16,7 @@ jobs:
   functional-tests:
     name: AppSignal MCP Server Functional Tests
     runs-on: self-hosted
+    timeout-minutes: 15
 
     defaults:
       run:
@@ -49,6 +50,7 @@ jobs:
   integration-tests:
     name: AppSignal MCP Server Integration Tests
     runs-on: self-hosted
+    timeout-minutes: 15
 
     defaults:
       run:

--- a/.github/workflows/claude-code-agent-ci.yml
+++ b/.github/workflows/claude-code-agent-ci.yml
@@ -16,6 +16,7 @@ jobs:
   functional-tests:
     name: Claude Code Agent MCP Server Functional Tests
     runs-on: self-hosted
+    timeout-minutes: 15
 
     defaults:
       run:
@@ -46,6 +47,7 @@ jobs:
   integration-tests:
     name: Claude Code Agent MCP Server Integration Tests
     runs-on: self-hosted
+    timeout-minutes: 15
 
     defaults:
       run:

--- a/.github/workflows/gcs-ci.yml
+++ b/.github/workflows/gcs-ci.yml
@@ -16,6 +16,7 @@ jobs:
   functional-tests:
     name: GCS MCP Server Functional Tests
     runs-on: self-hosted
+    timeout-minutes: 15
 
     defaults:
       run:
@@ -46,6 +47,7 @@ jobs:
   integration-tests:
     name: GCS MCP Server Integration Tests
     runs-on: self-hosted
+    timeout-minutes: 15
 
     defaults:
       run:

--- a/.github/workflows/hatchbox-ci.yml
+++ b/.github/workflows/hatchbox-ci.yml
@@ -16,6 +16,7 @@ jobs:
   functional-tests:
     name: Hatchbox MCP Server Functional Tests
     runs-on: self-hosted
+    timeout-minutes: 15
 
     defaults:
       run:
@@ -51,6 +52,7 @@ jobs:
   integration-tests:
     name: Hatchbox MCP Server Integration Tests
     runs-on: self-hosted
+    timeout-minutes: 15
 
     defaults:
       run:

--- a/.github/workflows/pulse-fetch-ci.yml
+++ b/.github/workflows/pulse-fetch-ci.yml
@@ -16,6 +16,7 @@ jobs:
   functional-tests:
     name: Pulse Fetch MCP Server Functional Tests
     runs-on: self-hosted
+    timeout-minutes: 15
 
     defaults:
       run:
@@ -49,6 +50,7 @@ jobs:
   integration-tests:
     name: Pulse Fetch MCP Server Integration Tests
     runs-on: self-hosted
+    timeout-minutes: 15
 
     defaults:
       run:

--- a/.github/workflows/slack-ci.yml
+++ b/.github/workflows/slack-ci.yml
@@ -16,6 +16,7 @@ jobs:
   functional-tests:
     name: Slack MCP Server Functional Tests
     runs-on: self-hosted
+    timeout-minutes: 15
 
     defaults:
       run:
@@ -48,6 +49,7 @@ jobs:
   integration-tests:
     name: Slack MCP Server Integration Tests
     runs-on: self-hosted
+    timeout-minutes: 15
 
     defaults:
       run:

--- a/.github/workflows/twist-ci.yml
+++ b/.github/workflows/twist-ci.yml
@@ -16,6 +16,7 @@ jobs:
   functional-tests:
     name: Twist MCP Server Functional Tests
     runs-on: self-hosted
+    timeout-minutes: 15
 
     defaults:
       run:
@@ -49,6 +50,7 @@ jobs:
   integration-tests:
     name: Twist MCP Server Integration Tests
     runs-on: self-hosted
+    timeout-minutes: 15
 
     defaults:
       run:


### PR DESCRIPTION
## Summary

Bulk sync of **1 servers** from internal monorepo (pulsemcp/pulsemcp @ `8458e4a2`).

### Servers synced

- \`agent-orchestrator\`

## Verification

- [x] Distribution script ran successfully for all 1 servers
- [x] File diff shows only incremental changes from previous sync
- [x] No test files or internal docs included