### PR TITLE
fix(ci): unblock publish workflow — runner/inputs contexts not allowed in job env

### DIFF
--- a/.github/workflows/publish-mcp-servers.yml
+++ b/.github/workflows/publish-mcp-servers.yml
@@ -41,7 +41,9 @@ jobs:
       SKIPPED_FILE: ${{ runner.temp }}/skipped.json
       PUBLISHED_FILE: ${{ runner.temp }}/published.json
       FAILED_FILE: ${{ runner.temp }}/failed.json
-      DRY_RUN: ${{ inputs.dry_run && 'true' || 'false' }}
+      # Don't use `inputs.dry_run` — the inputs context is unavailable on push events
+      # and causes a startup failure (0s, no jobs scheduled). github.event.inputs is null-safe.
+      DRY_RUN: ${{ github.event.inputs.dry_run == 'true' }}
 
     steps:
       - name: Checkout code

--- a/.github/workflows/publish-mcp-servers.yml
+++ b/.github/workflows/publish-mcp-servers.yml
@@ -35,19 +35,24 @@ jobs:
       packages: write
       checks: read
 
+    # Note: neither `runner` nor `inputs` is allowed in jobs.<id>.env — both cause
+    # "Unrecognized named-value" startup failures. runner.temp paths are exported
+    # below in a setup step (RUNNER_TEMP is set by the runner); the dry-run flag
+    # uses github.event.inputs (null-safe across all triggers).
     env:
-      CANDIDATES_FILE: ${{ runner.temp }}/candidates.json
-      READY_FILE: ${{ runner.temp }}/ready.json
-      SKIPPED_FILE: ${{ runner.temp }}/skipped.json
-      PUBLISHED_FILE: ${{ runner.temp }}/published.json
-      FAILED_FILE: ${{ runner.temp }}/failed.json
-      # Don't use `inputs.dry_run` — the inputs context is unavailable on push events
-      # and causes a startup failure (0s, no jobs scheduled). github.event.inputs is null-safe.
       DRY_RUN: ${{ github.event.inputs.dry_run == 'true' }}
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - name: Export temp file paths
+        run: |
+          echo "CANDIDATES_FILE=$RUNNER_TEMP/candidates.json" >> "$GITHUB_ENV"
+          echo "READY_FILE=$RUNNER_TEMP/ready.json" >> "$GITHUB_ENV"
+          echo "SKIPPED_FILE=$RUNNER_TEMP/skipped.json" >> "$GITHUB_ENV"
+          echo "PUBLISHED_FILE=$RUNNER_TEMP/published.json" >> "$GITHUB_ENV"
+          echo "FAILED_FILE=$RUNNER_TEMP/failed.json" >> "$GITHUB_ENV"
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/publish-mcp-servers.yml
+++ b/.github/workflows/publish-mcp-servers.yml
@@ -35,10 +35,11 @@ jobs:
       packages: write
       checks: read
 
-    # Note: neither `runner` nor `inputs` is allowed in jobs.<id>.env — both cause
-    # "Unrecognized named-value" startup failures. runner.temp paths are exported
-    # below in a setup step (RUNNER_TEMP is set by the runner); the dry-run flag
-    # uses github.event.inputs (null-safe across all triggers).
+    # Note: don't reference `runner.*` or `inputs.*` here. `runner` is disallowed in
+    # jobs.<id>.env, and `inputs` is undefined on push triggers — both surface as
+    # "Unrecognized named-value" startup failures (no jobs scheduled). runner.temp
+    # paths are exported in a setup step using $RUNNER_TEMP; the dry-run flag uses
+    # github.event.inputs, which is null-safe across all triggers.
     env:
       DRY_RUN: ${{ github.event.inputs.dry_run == 'true' }}
 


### PR DESCRIPTION
## Summary

The `publish-mcp-servers.yml` workflow has been failing on every push since #564 was merged on 2026-04-26 — `conclusion: failure`, 0s runtime, 0 jobs scheduled. GitHub's run page reports: _"This run likely failed because of a workflow file issue."_ The exact error visible in the UI is:

> `Unrecognized named-value: 'runner'. Located at position 1 within expression: runner.temp`

#564 introduced two illegal context references in the job's env block:

```yaml
env:
  CANDIDATES_FILE: ${{ runner.temp }}/candidates.json   # runner is disallowed in jobs.<id>.env
  ...
  DRY_RUN: ${{ inputs.dry_run && 'true' || 'false' }}   # inputs is undefined on push triggers
```

Per GitHub's [context-availability matrix](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/accessing-contextual-information-about-workflow-runs#context-availability), `runner` is not permitted in `jobs.<job_id>.env`. `inputs` is technically permitted at that scope but is undefined for `push` triggers (since `inputs` only exists for `workflow_dispatch`/`workflow_call`), and the runner surfaces both as "Unrecognized named-value" startup failures before any job is scheduled. This is also why the failure showed up on non-main pushes despite the `branches: [main]` filter — the filter is applied after validation succeeds; validation never gets that far.

### Fix

- `runner.temp` paths are exported in a small setup step that writes them to `$GITHUB_ENV` using `$RUNNER_TEMP` (which the runner sets automatically as a shell variable). Subsequent steps still see them as plain env vars, so no callsite changes were needed.
- `inputs.dry_run` is replaced with `github.event.inputs.dry_run == 'true'`. The `github` context is allowed in job env, `github.event.inputs` is null-safe across all triggers, and the comparison stringifies to `"true"`/`"false"` for the existing bash check.

This unblocks the sweep that publishes `onepassword-mcp-server@0.3.5` and `gmail-workspace-mcp-server@0.4.7` to npm. Downstream of this fix: AO session [#4480](https://ao.pulsemcp.com/sessions/4480).

## Verification

- [x] **YAML still parses** locally (`js-yaml` round-trip): `Parses OK. Steps: [Checkout code, Export temp file paths, Setup Node.js, Sweep for unpublished versions, Per-server CI gate, Publish ready servers, Write summary and set exit code]`
- [x] **Validation now passes on push**: the first commit on this branch (which only fixed `inputs`, not `runner`) still produced a failed `publish-mcp-servers.yml` run on the branch push — proving `runner.temp` was a second blocker even on a non-main branch where the workflow's `branches: [main]` filter would otherwise exclude it. After the second commit (which fixed `runner.temp`), **no new `publish-mcp-servers.yml` run was created** for the branch push. The branch filter is now reached and correctly excludes non-main branches → the YAML is valid. See run [24960487948](https://github.com/pulsemcp/mcp-servers/actions/runs/24960487948) (the last failure, on the first commit) and the absence of any subsequent run for the branch.
- [x] **PR CI is green**: `Lint & Type Check`, `CI Build & Test Checks Passed`, and `Validate Publish Files` all pass on this PR.
- [x] **Fresh-eyes subagent review**: independently verified the diagnosis against GitHub's docs and the failed run logs; confirmed `$RUNNER_TEMP` is reliably set on self-hosted runners; confirmed the `github.event.inputs.dry_run == 'true'` semantics; one framing nit applied in a follow-up commit.
- [x] **Self-reviewed the diff**: only `.github/workflows/publish-mcp-servers.yml` is touched, additions/removals are 1:1 with the bug.

## After merge (note for reviewer)

Once merged, the next push to `main` (or a manual `workflow_dispatch`) will sweep the unpublished versions and push `onepassword-mcp-server@0.3.5` and `gmail-workspace-mcp-server@0.4.7` to npm.