### PR TITLE
Sync 6 servers from monorepo

### DIFF
--- a/experimental/agent-orchestrator/package-lock.json
+++ b/experimental/agent-orchestrator/package-lock.json
@@ -2174,9 +2174,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
-      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"

--- a/experimental/google-docs/package-lock.json
+++ b/experimental/google-docs/package-lock.json
@@ -31,7 +31,7 @@
     },
     "local": {
       "name": "google-docs-workspace-mcp-server",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
@@ -2245,9 +2245,10 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
-      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+      "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
       },

--- a/experimental/google-docs/server.json
+++ b/experimental/google-docs/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
   "name": "com.pulsemcp/google-docs",
   "description": "MCP server for Google Docs integration with OAuth2 and service account support.",
-  "version": "0.1.2",
+  "version": "0.1.1",
   "repository": {
     "url": "https://github.com/pulsemcp/mcp-servers",
     "source": "github",
@@ -13,7 +13,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "google-docs-workspace-mcp-server",
-      "version": "0.1.2",
+      "version": "0.1.1",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"

--- a/experimental/monarch-money/package-lock.json
+++ b/experimental/monarch-money/package-lock.json
@@ -21,7 +21,7 @@
     },
     "local": {
       "name": "monarch-money-mcp-server",
-      "version": "0.0.6",
+      "version": "0.0.7",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
@@ -1966,7 +1966,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.1",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"

--- a/experimental/monarch-money/server.json
+++ b/experimental/monarch-money/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
   "name": "com.pulsemcp/monarch-money",
   "description": "MCP server for Monarch Money — account, transaction, and budget management.",
-  "version": "0.0.7",
+  "version": "0.0.6",
   "repository": {
     "url": "https://github.com/pulsemcp/mcp-servers",
     "source": "github",
@@ -13,7 +13,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "monarch-money-mcp-server",
-      "version": "0.0.7",
+      "version": "0.0.6",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"

--- a/experimental/proctor/package-lock.json
+++ b/experimental/proctor/package-lock.json
@@ -31,7 +31,7 @@
     },
     "local": {
       "name": "proctor-mcp-server",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
@@ -2097,9 +2097,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
-      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"

--- a/experimental/proctor/server.json
+++ b/experimental/proctor/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
   "name": "com.pulsemcp/proctor",
   "description": "MCP server for running Proctor exams against MCP servers with exam execution and result management.",
-  "version": "0.1.8",
+  "version": "0.1.7",
   "repository": {
     "url": "https://github.com/pulsemcp/mcp-servers",
     "source": "github",
@@ -13,7 +13,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "proctor-mcp-server",
-      "version": "0.1.8",
+      "version": "0.1.7",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"

--- a/experimental/pulsemcp-cms-admin/package-lock.json
+++ b/experimental/pulsemcp-cms-admin/package-lock.json
@@ -41,7 +41,7 @@
     },
     "local": {
       "name": "pulsemcp-cms-admin-mcp-server",
-      "version": "0.9.27",
+      "version": "0.9.28",
       "bundleDependencies": [
         "@pulsemcp/mcp-elicitation"
       ],
@@ -2192,9 +2192,9 @@
       "link": true
     },
     "node_modules/qs": {
-      "version": "6.15.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
-      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"

--- a/experimental/pulsemcp-cms-admin/server.json
+++ b/experimental/pulsemcp-cms-admin/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
   "name": "com.pulsemcp/pulsemcp-cms-admin",
   "description": "MCP server for managing PulseMCP's CMS — newsletter and MCP server directory.",
-  "version": "0.9.28",
+  "version": "0.9.27",
   "repository": {
     "url": "https://github.com/pulsemcp/mcp-servers",
     "source": "github",
@@ -13,7 +13,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "pulsemcp-cms-admin-mcp-server",
-      "version": "0.9.28",
+      "version": "0.9.27",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"

--- a/libs/test-mcp-client/package-lock.json
+++ b/libs/test-mcp-client/package-lock.json
@@ -1303,9 +1303,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
-      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"

--- a/productionized/pulse-subregistry/package-lock.json
+++ b/productionized/pulse-subregistry/package-lock.json
@@ -32,7 +32,7 @@
     },
     "local": {
       "name": "@pulsemcp/pulse-subregistry",
-      "version": "0.0.6",
+      "version": "0.0.7",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
@@ -2087,9 +2087,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
-      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"

--- a/productionized/pulse-subregistry/server.json
+++ b/productionized/pulse-subregistry/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
   "name": "com.pulsemcp/pulse-subregistry",
   "description": "MCP server providing access to the PulseMCP Sub-Registry for browsing and discovering MCP servers.",
-  "version": "0.0.7",
+  "version": "0.0.6",
   "repository": {
     "url": "https://github.com/pulsemcp/mcp-servers",
     "source": "github",
@@ -13,7 +13,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "@pulsemcp/pulse-subregistry",
-      "version": "0.0.7",
+      "version": "0.0.6",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
## Summary

Bulk sync of **6 servers** from internal monorepo (pulsemcp/pulsemcp @ `ac322f8d`).

### Servers synced

- \`agent-orchestrator\`
- \`google-docs\`
- \`monarch-money\`
- \`proctor\`
- \`pulse-subregistry\`
- \`pulsemcp-cms-admin\`

## Verification

- [x] Distribution script ran successfully for all 6 servers
- [x] File diff shows only incremental changes from previous sync
- [x] No test files or internal docs included