### PR TITLE
Sync 28 servers from monorepo

### DIFF
--- a/experimental/appsignal/server.json
+++ b/experimental/appsignal/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
   "name": "com.pulsemcp/appsignal",
   "description": "MCP server for AppSignal — get alert details, search logs, and retrieve logs within time ranges.",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "repository": {
     "url": "https://github.com/pulsemcp/mcp-servers",
     "source": "github",
@@ -13,7 +13,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "appsignal-mcp-server",
-      "version": "0.5.2",
+      "version": "0.5.3",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"

--- a/experimental/dynamodb/server.json
+++ b/experimental/dynamodb/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
   "name": "com.pulsemcp/dynamodb",
   "description": "MCP server for AWS DynamoDB with fine-grained tool control and configurable access levels.",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "repository": {
     "url": "https://github.com/pulsemcp/mcp-servers",
     "source": "github",
@@ -13,7 +13,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "aws-dynamodb-mcp-server",
-      "version": "0.2.5",
+      "version": "0.2.6",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"

--- a/experimental/fetchpet/server.json
+++ b/experimental/fetchpet/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
   "name": "com.pulsemcp/fetchpet",
   "description": "MCP server for Fetch Pet insurance claims management using Playwright automation.",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "repository": {
     "url": "https://github.com/pulsemcp/mcp-servers",
     "source": "github",
@@ -13,7 +13,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "fetchpet-mcp-server",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"

--- a/experimental/fly-io/server.json
+++ b/experimental/fly-io/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
   "name": "com.pulsemcp/fly-io",
   "description": "MCP server for managing Fly.io machines, apps, logs, and Docker images.",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "repository": {
     "url": "https://github.com/pulsemcp/mcp-servers",
     "source": "github",
@@ -13,7 +13,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "fly-io-mcp-server",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"

--- a/experimental/gcs/server.json
+++ b/experimental/gcs/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
   "name": "com.pulsemcp/gcs",
   "description": "MCP server for Google Cloud Storage with fine-grained tool access control.",
-  "version": "0.1.7",
+  "version": "0.1.11",
   "repository": {
     "url": "https://github.com/pulsemcp/mcp-servers",
     "source": "github",
@@ -13,7 +13,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "gcs-google-mcp-server",
-      "version": "0.1.7",
+      "version": "0.1.11",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"

--- a/experimental/good-eggs/server.json
+++ b/experimental/good-eggs/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
   "name": "com.pulsemcp/good-eggs",
   "description": "MCP server for Good Eggs grocery shopping automation using Playwright.",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "repository": {
     "url": "https://github.com/pulsemcp/mcp-servers",
     "source": "github",
@@ -13,7 +13,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "good-eggs-mcp-server",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"

--- a/experimental/google-calendar/server.json
+++ b/experimental/google-calendar/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
   "name": "com.pulsemcp/google-calendar",
   "description": "MCP server for Google Calendar integration with service account support and domain-wide delegation.",
-  "version": "0.0.8",
+  "version": "0.0.12",
   "repository": {
     "url": "https://github.com/pulsemcp/mcp-servers",
     "source": "github",
@@ -13,7 +13,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "google-calendar-workspace-mcp-server",
-      "version": "0.0.8",
+      "version": "0.0.12",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"

--- a/experimental/google-docs/server.json
+++ b/experimental/google-docs/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
   "name": "com.pulsemcp/google-docs",
   "description": "MCP server for Google Docs integration with OAuth2 and service account support.",
-  "version": "0.1.1",
+  "version": "0.1.3",
   "repository": {
     "url": "https://github.com/pulsemcp/mcp-servers",
     "source": "github",
@@ -13,7 +13,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "google-docs-workspace-mcp-server",
-      "version": "0.1.1",
+      "version": "0.1.3",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"

--- a/experimental/google-flights/server.json
+++ b/experimental/google-flights/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
   "name": "com.pulsemcp/google-flights",
   "description": "MCP server for searching Google Flights — flight search, date grid pricing, and airport lookup.",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "repository": {
     "url": "https://github.com/pulsemcp/mcp-servers",
     "source": "github",
@@ -13,7 +13,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "google-flights-mcp-server",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"

--- a/experimental/hatchbox/server.json
+++ b/experimental/hatchbox/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
   "name": "com.pulsemcp/hatchbox",
   "description": "MCP server for Hatchbox Rails hosting — env var inspection, deploys, and process monitoring.",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "repository": {
     "url": "https://github.com/pulsemcp/mcp-servers",
     "source": "github",
@@ -13,7 +13,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "hatchbox-mcp-server",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"

--- a/experimental/langfuse/server.json
+++ b/experimental/langfuse/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
   "name": "com.pulsemcp/langfuse",
   "description": "MCP server for Langfuse LLM observability — trace and observation analysis.",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "repository": {
     "url": "https://github.com/pulsemcp/mcp-servers",
     "source": "github",
@@ -13,7 +13,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "langfuse-observability-mcp-server",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"

--- a/experimental/monarch-money/server.json
+++ b/experimental/monarch-money/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
   "name": "com.pulsemcp/monarch-money",
   "description": "MCP server for Monarch Money — account, transaction, and budget management.",
-  "version": "0.0.6",
+  "version": "0.0.8",
   "repository": {
     "url": "https://github.com/pulsemcp/mcp-servers",
     "source": "github",
@@ -13,7 +13,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "monarch-money-mcp-server",
-      "version": "0.0.6",
+      "version": "0.0.8",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"

--- a/experimental/playwright-stealth/server.json
+++ b/experimental/playwright-stealth/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
   "name": "com.pulsemcp/playwright-stealth",
   "description": "Browser automation using Playwright with optional stealth mode to bypass anti-bot protection.",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "repository": {
     "url": "https://github.com/pulsemcp/mcp-servers",
     "source": "github",
@@ -13,7 +13,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "playwright-stealth-mcp-server",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"

--- a/experimental/pointsyeah/server.json
+++ b/experimental/pointsyeah/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
   "name": "com.pulsemcp/pointsyeah",
   "description": "MCP server for searching award flights and travel deals via PointsYeah.",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "repository": {
     "url": "https://github.com/pulsemcp/mcp-servers",
     "source": "github",
@@ -13,7 +13,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "pointsyeah-mcp-server",
-      "version": "0.2.7",
+      "version": "0.2.8",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"

--- a/experimental/proctor/server.json
+++ b/experimental/proctor/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
   "name": "com.pulsemcp/proctor",
   "description": "MCP server for running Proctor exams against MCP servers with exam execution and result management.",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "repository": {
     "url": "https://github.com/pulsemcp/mcp-servers",
     "source": "github",
@@ -13,7 +13,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "proctor-mcp-server",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"

--- a/experimental/remote-filesystem/server.json
+++ b/experimental/remote-filesystem/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
   "name": "com.pulsemcp/remote-filesystem",
   "description": "MCP server for remote filesystem operations on cloud storage (Google Cloud Storage).",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "repository": {
     "url": "https://github.com/pulsemcp/mcp-servers",
     "source": "github",
@@ -13,7 +13,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "remote-filesystem-mcp-server",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"

--- a/experimental/s3/server.json
+++ b/experimental/s3/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
   "name": "com.pulsemcp/s3",
   "description": "MCP server for AWS S3 with fine-grained tool control and S3-compatible endpoint support.",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "repository": {
     "url": "https://github.com/pulsemcp/mcp-servers",
     "source": "github",
@@ -13,7 +13,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "s3-aws-mcp-server",
-      "version": "0.0.3",
+      "version": "0.0.4",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"

--- a/experimental/serpapi-hotels/server.json
+++ b/experimental/serpapi-hotels/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
   "name": "com.pulsemcp/serpapi-hotels",
   "description": "MCP server for searching Google Hotels via SerpAPI — hotel search, pricing, ratings, and reviews.",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "repository": {
     "url": "https://github.com/pulsemcp/mcp-servers",
     "source": "github",
@@ -13,7 +13,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "serpapi-hotels-mcp-server",
-      "version": "0.0.2",
+      "version": "0.0.3",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"

--- a/experimental/slack/server.json
+++ b/experimental/slack/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
   "name": "com.pulsemcp/slack",
   "description": "MCP server for Slack — read/write messages, manage threads, and react to messages.",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "repository": {
     "url": "https://github.com/pulsemcp/mcp-servers",
     "source": "github",
@@ -13,7 +13,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "slack-workspace-mcp-server",
-      "version": "0.0.5",
+      "version": "0.0.6",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"

--- a/experimental/ssh/server.json
+++ b/experimental/ssh/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
   "name": "com.pulsemcp/ssh",
   "description": "MCP server for SSH remote server management with SSH agent authentication support.",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "repository": {
     "url": "https://github.com/pulsemcp/mcp-servers",
     "source": "github",
@@ -13,7 +13,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "ssh-agent-mcp-server",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"

--- a/experimental/twist/server.json
+++ b/experimental/twist/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
   "name": "com.pulsemcp/twist",
   "description": "MCP server for Twist team messaging — manage channels, threads, and messages.",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "repository": {
     "url": "https://github.com/pulsemcp/mcp-servers",
     "source": "github",
@@ -13,7 +13,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "twist-mcp-server",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"

--- a/experimental/vercel/server.json
+++ b/experimental/vercel/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
   "name": "com.pulsemcp/vercel",
   "description": "MCP server for Vercel — manage deployments and view build and runtime application logs.",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "repository": {
     "url": "https://github.com/pulsemcp/mcp-servers",
     "source": "github",
@@ -13,7 +13,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "vercel-platform-mcp-server",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"

--- a/productionized/image-diff/server.json
+++ b/productionized/image-diff/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
   "name": "com.pulsemcp/image-diff",
   "description": "MCP server for programmatic image comparison and visual diff generation.",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "repository": {
     "url": "https://github.com/pulsemcp/mcp-servers",
     "source": "github",
@@ -13,7 +13,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "@pulsemcp/image-diff-mcp-server",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"

--- a/productionized/pulse-fetch/server.json
+++ b/productionized/pulse-fetch/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
   "name": "com.pulsemcp/pulse-fetch",
   "description": "MCP server for fetching web resources with content extraction and anti-bot bypass.",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "repository": {
     "url": "https://github.com/pulsemcp/mcp-servers",
     "source": "github",
@@ -13,7 +13,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "@pulsemcp/pulse-fetch",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"

--- a/productionized/pulse-subregistry/server.json
+++ b/productionized/pulse-subregistry/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
   "name": "com.pulsemcp/pulse-subregistry",
   "description": "MCP server providing access to the PulseMCP Sub-Registry for browsing and discovering MCP servers.",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "repository": {
     "url": "https://github.com/pulsemcp/mcp-servers",
     "source": "github",
@@ -13,7 +13,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "@pulsemcp/pulse-subregistry",
-      "version": "0.0.6",
+      "version": "0.0.7",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"

--- a/productionized/svg-tracer/server.json
+++ b/productionized/svg-tracer/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
   "name": "com.pulsemcp/svg-tracer",
   "description": "MCP server for converting bitmap images to SVG vector graphics using potrace tracing.",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "repository": {
     "url": "https://github.com/pulsemcp/mcp-servers",
     "source": "github",
@@ -13,7 +13,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "@pulsemcp/svg-tracer-mcp-server",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
## Summary

Bulk sync of **28 servers** from internal monorepo (pulsemcp/pulsemcp @ `2d5f26f5`).

### Servers synced

- \`appsignal\`
- \`dynamodb\`
- \`fetchpet\`
- \`fly-io\`
- \`gcs\`
- \`gmail\`
- \`good-eggs\`
- \`google-calendar\`
- \`google-docs\`
- \`google-flights\`
- \`hatchbox\`
- \`image-diff\`
- \`langfuse\`
- \`monarch-money\`
- \`onepassword\`
- \`playwright-stealth\`
- \`pointsyeah\`
- \`proctor\`
- \`pulse-fetch\`
- \`pulse-subregistry\`
- \`remote-filesystem\`
- \`s3\`
- \`serpapi-hotels\`
- \`slack\`
- \`ssh\`
- \`svg-tracer\`
- \`twist\`
- \`vercel\`

## Verification

- [x] Distribution script ran successfully for all 28 servers
- [x] File diff shows only incremental changes from previous sync
- [x] No test files or internal docs included