### PR TITLE
Fail fast on invalid npm mcpName before registry publish

### DIFF
--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -109,6 +109,106 @@ jobs:
             --domain pulsemcp.com \
             --private-key "$MCP_PRIVATE_KEY"
 
+      - name: Validate pinned npm mcpName values
+        if: steps.scan.outputs.count != '0'
+        run: |
+          set -euo pipefail
+          node <<'NODE'
+          const fs = require('node:fs');
+          const { execFileSync } = require('node:child_process');
+
+          const scan = JSON.parse(fs.readFileSync('/tmp/scan.json', 'utf8'));
+          const failures = [];
+
+          function oneLine(value) {
+            return String(value).replace(/\s+/g, ' ').trim();
+          }
+
+          function workflowCommandValue(value) {
+            return oneLine(value).replace(/%/g, '%25').replace(/\r/g, '%0D').replace(/\n/g, '%0A');
+          }
+
+          function npmViewMcpName(identifier, version, registryBaseUrl) {
+            const spec = `${identifier}@${version}`;
+            const args = ['view', spec, 'mcpName', '--json'];
+            if (registryBaseUrl) args.push('--registry', registryBaseUrl);
+            try {
+              const output = execFileSync('npm', args, {
+                encoding: 'utf8',
+                stdio: ['ignore', 'pipe', 'pipe'],
+              }).trim();
+
+              if (!output) return null;
+              const parsed = JSON.parse(output);
+              return typeof parsed === 'string' && parsed.length > 0 ? parsed : null;
+            } catch (error) {
+              const stderr = error.stderr ? String(error.stderr).trim() : '';
+              throw new Error(stderr || error.message);
+            }
+          }
+
+          for (const candidate of scan.candidates) {
+            const manifest = JSON.parse(fs.readFileSync(candidate.sjPath, 'utf8'));
+            const expected = manifest.name;
+            const pkg = manifest.packages?.[0];
+            const identifier = pkg?.identifier;
+            const version = pkg?.version;
+            const registryBaseUrl = pkg?.registryBaseUrl;
+            const server = `${candidate.name}@${candidate.version}`;
+
+            if (!identifier || !version) {
+              failures.push({
+                server,
+                packageSpec: identifier && version ? `${identifier}@${version}` : '(missing packages[0].identifier or packages[0].version)',
+                expected,
+                actual: 'missing package metadata in server.json',
+              });
+              continue;
+            }
+
+            let actual;
+            try {
+              actual = npmViewMcpName(identifier, version, registryBaseUrl);
+            } catch (error) {
+              failures.push({
+                server,
+                packageSpec: `${identifier}@${version}`,
+                expected,
+                actual: `npm lookup failed: ${error.message}`,
+              });
+              continue;
+            }
+
+            if (actual !== expected) {
+              failures.push({
+                server,
+                packageSpec: `${identifier}@${version}`,
+                expected,
+                actual: actual ?? 'missing',
+              });
+            } else {
+              console.log(`✓ ${server}: ${identifier}@${version} mcpName matches ${expected}`);
+            }
+          }
+
+          if (failures.length > 0) {
+            console.error('\nPinned npm package mcpName validation failed.');
+            console.error('The MCP Registry validates each server.json name against the exact published npm package version in packages[0].');
+            console.error('Republish the npm package with the corrected mcpName, or bump server.json packages[0].version to a version that already has it.\n');
+
+            for (const failure of failures) {
+              console.error(`Server: ${failure.server}`);
+              console.error(`npm package checked: ${failure.packageSpec}`);
+              console.error(`Expected mcpName: ${failure.expected}`);
+              console.error(`Actual mcpName: ${failure.actual}`);
+              console.error('Remedy: republish this npm package version with the corrected mcpName, or bump server.json to a corrected published version.');
+              console.error('');
+              console.error(`::error title=Invalid npm mcpName for ${workflowCommandValue(failure.server)}::${workflowCommandValue(failure.packageSpec)} has mcpName ${workflowCommandValue(failure.actual)}; expected ${workflowCommandValue(failure.expected)}. Republish the npm package with the corrected mcpName, or bump server.json to a version that already has it.`);
+            }
+            process.exit(1);
+          }
+          NODE
+
       - name: Publish candidates
         id: publish
         if: steps.scan.outputs.count != '0'


### PR DESCRIPTION
## Summary
Add a pre-flight guard to the `Publish to MCP Registry` workflow that validates each publish candidate's exact pinned npm package version before `mcp-publisher publish` runs.

For every candidate from `/tmp/scan.json`, the workflow now rereads `server.json`, checks `packages[0].identifier` + `packages[0].version` with `npm view <identifier>@<version> mcpName --json`, and fails with an actionable error if the published package is missing `mcpName`, has a stale value, or cannot be looked up. The lookup also honors `packages[0].registryBaseUrl` when present, and the validation runs during dry runs as well as real publish runs.

This replaces the late opaque failure seen in https://github.com/pulsemcp/mcp-servers/actions/runs/27441491272 (`HTTP 400 registry validation failed`) with a targeted validation step before publishing.

Design note: I left `publish-mcp-registry.yml` in the public repo because this task was explicitly scoped to the public repo workflow, and the background notes say it is not currently mirrored by `public-repo-config/` and will not be overwritten by the additive sync. It may still be worth a follow-up in the monorepo root to decide whether this workflow should become mirrored long term for consistency with other CI workflows.

## Verification
- [x] CI green on final commit `a91bb87`: `CI Build & Test Checks Passed` passed in 1m11s, `Lint & Type Check` passed in 1m03s, and `Validate Publish Files` passed in 11s on https://github.com/pulsemcp/mcp-servers/pull/634.
- [x] Syntax: extracted the embedded workflow Node body and ran `node --check /tmp/validate-mcpname.js`; it completed with no syntax errors.
- [x] Formatting: ran `npx prettier --check .github/workflows/publish-mcp-registry.yml`; output: `All matched files use Prettier code style!`.
- [x] Diff hygiene: ran `git diff --check`; it completed with no whitespace errors.
- [x] Existing scan still works: ran `node .github/scripts/mcp-registry-scan.mjs > /tmp/scan.json && node -p "JSON.parse(require('fs').readFileSync('/tmp/scan.json','utf8')).candidates.length"`; current repo data reported `0` candidates.
- [x] Synthetic pass proof: ran the extracted validation script with fake `npm view demo-package@1.2.3 mcpName --json` returning `"com.pulsemcp/demo"`; output included `✓ com.pulsemcp/demo@1.2.3: demo-package@1.2.3 mcpName matches com.pulsemcp/demo` and exited `0`.
- [x] Synthetic missing-field proof: ran the extracted validation script with fake `npm view missing-package@1.2.3 mcpName --json` returning an empty value; output included `Server: com.pulsemcp/demo@1.2.3`, `npm package checked: missing-package@1.2.3`, `Expected mcpName: com.pulsemcp/demo`, `Actual mcpName: missing`, and exited `1`.
- [x] Synthetic mismatch proof: ran the extracted validation script with fake `npm view stale-package@1.2.3 mcpName --json` returning `"com.pulsemcp.servers/demo"`; output included `Actual mcpName: com.pulsemcp.servers/demo`, `expected com.pulsemcp/demo`, the republish-or-bump remedy, and exited `1`.
- [x] Synthetic npm lookup failure proof: ran the extracted validation script with fake `npm view absent-package@1.2.3 mcpName --json` exiting with a 404; output included `Actual mcpName: npm lookup failed: npm error 404 absent-package@1.2.3 is not in this registry.`, the package checked, expected value, remedy, and exited `1`.
- [x] Self-review completed: hardened the initial diff so GitHub workflow-command annotation values are escaped, npm lookups honor `registryBaseUrl`, and the validation also runs for dry-run candidates.
- [x] Fresh-eyes subagent review completed: it flagged workflow-command escaping and `registryBaseUrl` as warnings and dry-run coverage as a nit; all three were addressed in the final diff.
