### PR TITLE
Sync 24 servers from monorepo

### DIFF
--- a/experimental/pulsemcp-cms-admin/server.json
+++ b/experimental/pulsemcp-cms-admin/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
   "name": "com.pulsemcp/pulsemcp-cms-admin",
   "description": "MCP server for managing PulseMCP's CMS — newsletter and MCP server directory.",
-  "version": "0.9.27",
+  "version": "0.10.2",
   "repository": {
     "url": "https://github.com/pulsemcp/mcp-servers",
     "source": "github",
@@ -13,7 +13,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "pulsemcp-cms-admin-mcp-server",
-      "version": "0.9.27",
+      "version": "0.10.2",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
## Summary

Bulk sync of **24 servers** from internal monorepo (pulsemcp/pulsemcp @ `7c646156`).

### Servers synced

- \`agent-orchestrator\`
- \`appsignal\`
- \`claude-code-agent\`
- \`dynamodb\`
- \`fetchpet\`
- \`fly-io\`
- \`gcs\`
- \`gmail\`
- \`good-eggs\`
- \`google-docs\`
- \`hatchbox\`
- \`onepassword\`
- \`playwright-stealth\`
- \`pointsyeah\`
- \`proctor\`
- \`pulse-fetch\`
- \`pulse-subregistry\`
- \`pulsemcp-cms-admin\`
- \`remote-filesystem\`
- \`s3\`
- \`ssh\`
- \`svg-tracer\`
- \`twist\`
- \`vercel\`

## Verification

- [x] Distribution script ran successfully for all 24 servers
- [x] File diff shows only incremental changes from previous sync
- [x] No test files or internal docs included