### PR TITLE
Harden verify-publications CI against corrupt npm cache on self-hosted runners

### DIFF
--- a/.github/workflows/verify-mcp-server-publication.yml
+++ b/.github/workflows/verify-mcp-server-publication.yml
@@ -41,6 +41,53 @@ jobs:
           # Track if any verification fails
           VERIFICATION_FAILED=false
 
+          # Run an npm command, self-healing if it fails due to a corrupt shared
+          # npm cache on the self-hosted runners. Those runners share a
+          # persistent cache at ~/.npm/_cacache; when a content file goes
+          # missing, `npm install` dies with an ENOENT stat'ing
+          # _cacache/content-v2/... (see incident on 2026-07-01, verify run
+          # 28544837977). On that specific signature we garbage-collect broken
+          # entries with `npm cache verify` and retry once; if it still fails we
+          # escalate to a forced `npm cache clean --force` and retry a final
+          # time. Non-cache failures are surfaced unchanged.
+          run_npm_with_cache_heal() {
+            local logfile status
+            logfile=$(mktemp)
+
+            "$@" >"$logfile" 2>&1 && status=0 || status=$?
+            cat "$logfile"
+            if [ "$status" -eq 0 ]; then
+              rm -f "$logfile"
+              return 0
+            fi
+
+            if ! grep -qiE "ENOENT.*_cacache|_cacache.*ENOENT|Invalid response body while trying to fetch" "$logfile"; then
+              # Not a corrupt-cache failure — nothing to heal.
+              rm -f "$logfile"
+              return "$status"
+            fi
+
+            echo "⚠️  Detected corrupt npm cache — running 'npm cache verify' and retrying..."
+            npm cache verify || true
+            "$@" >"$logfile" 2>&1 && status=0 || status=$?
+            cat "$logfile"
+            if [ "$status" -eq 0 ]; then
+              echo "✅ Recovered after 'npm cache verify'"
+              rm -f "$logfile"
+              return 0
+            fi
+
+            echo "⚠️  Still failing — running 'npm cache clean --force' and retrying once more..."
+            npm cache clean --force || true
+            "$@" >"$logfile" 2>&1 && status=0 || status=$?
+            cat "$logfile"
+            if [ "$status" -eq 0 ]; then
+              echo "✅ Recovered after 'npm cache clean --force'"
+            fi
+            rm -f "$logfile"
+            return "$status"
+          }
+
           for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
             echo "Checking $file"
             
@@ -175,12 +222,25 @@ jobs:
             echo "Running tests for $SERVER_NAME..."
             cd "$SERVER_DIR"
             
-            # Install dependencies - use ci:install if available, otherwise npm install
-            if npm run --silent ci:install 2>/dev/null; then
-              echo "✅ Dependencies installed with ci:install"
+            # Install dependencies - use ci:install if available, otherwise npm install.
+            # Route through run_npm_with_cache_heal so a corrupt shared npm cache
+            # on the self-hosted runner is garbage-collected and the install
+            # retried, rather than failing the whole verification run.
+            if node -e "process.exit((require('./package.json').scripts||{})['ci:install']?0:1)" 2>/dev/null; then
+              if run_npm_with_cache_heal npm run ci:install; then
+                echo "✅ Dependencies installed with ci:install"
+              else
+                echo "❌ ERROR: Dependency install failed (ci:install)"
+                VERIFICATION_FAILED=true
+              fi
             else
               echo "ℹ️  No ci:install script found, using npm install"
-              npm install
+              if run_npm_with_cache_heal npm install; then
+                echo "✅ Dependencies installed with npm install"
+              else
+                echo "❌ ERROR: Dependency install failed (npm install)"
+                VERIFICATION_FAILED=true
+              fi
             fi
             
             # Run build

--- a/.github/workflows/verify-mcp-server-publication.yml
+++ b/.github/workflows/verify-mcp-server-publication.yml
@@ -230,7 +230,9 @@ jobs:
               if run_npm_with_cache_heal npm run ci:install; then
                 echo "✅ Dependencies installed with ci:install"
               else
-                echo "❌ ERROR: Dependency install failed (ci:install)"
+                # ci:install often also builds workspace deps, so a failure here
+                # is not necessarily an install error — keep the label generic.
+                echo "❌ ERROR: ci:install step failed"
                 VERIFICATION_FAILED=true
               fi
             else


### PR DESCRIPTION
## Summary

Makes the `verify-publications` workflow (`.github/workflows/verify-mcp-server-publication.yml`) resilient to a **corrupted npm cache** on our self-hosted GitHub Actions runners. This is a durable-prevention fix for a CI flake that fired on 2026-07-01.

**Root cause.** The self-hosted runners share a persistent npm cache at `/home/runner/.npm/_cacache`. When a cache entry's content file goes missing/corrupt, `npm install` blows up with an ENOENT stat'ing `_cacache/content-v2/...`:

```
npm error code ENOENT
npm error enoent Invalid response body while trying to fetch
https://registry.npmjs.org/typescript: ENOENT: no such file or directory,
stat '/home/runner/.npm/_cacache/content-v2/sha512/58/2b/...'
```

This failed the "Verify each changed MCP server" step on distribution PR #658 (monarch-money v0.0.12 sync), failed run: https://github.com/pulsemcp/mcp-servers/actions/runs/28544837977 . It was **not** a code defect — a re-run on a clean cache went green and #658 auto-merged. This PR only prevents recurrence.

**Fix.** A `run_npm_with_cache_heal` shell helper wraps the per-server dependency install. On the specific corrupt-cache signature it self-heals:
1. `npm cache verify` (lighter touch — garbage-collects broken entries) + retry once
2. escalate to `npm cache clean --force` + retry once more

Non-cache failures are surfaced unchanged (no masking of real errors). The install detection was also switched from *running* `ci:install` to a static `package.json` script check so it can be routed through the helper cleanly (this also fixes a latent quirk where a genuinely-failing `ci:install` was misread as "no ci:install script").

Scope is deliberately limited to the install step where the incident occurred; the rest of the workflow is untouched.

## Ownership note

`verify-mcp-server-publication.yml` is public-repo-owned (no sync/`DO NOT EDIT` marker; this public repo has no `distribute.sh`), so editing it here — rather than in the internal monorepo's `public-repo-config/` — is correct. Sibling `*-ci.yml` workflows address a *different* cache flake (concurrent `_cacache/tmp` EEXIST collisions) via per-job cache isolation; that mechanism doesn't recover a corrupt *shared* entry, which is why this workflow gets in-place self-heal instead.

## Verification

- [x] **YAML valid**: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/verify-mcp-server-publication.yml'))"` → `YAML OK`
- [x] **Prettier clean**: `npx prettier --check .github/workflows/verify-mcp-server-publication.yml` → "All matched files use Prettier code style!"
- [x] **Helper logic tested locally** with a fake `npm` that fails once with the exact `_cacache` ENOENT signature then succeeds:
  - Case A (corrupt-then-recover): heal path runs, returns exit 0 → **PASS**
  - Case B (unrelated failure): heal path NOT triggered, returns non-zero → **PASS** (real errors are not masked)
  - Case C (clean success): returns exit 0, no heal → **PASS**
- [x] **`ci:install` detection tested**: `node -e` script check returns exit 0 when `scripts["ci:install"]` exists, exit 1 when absent
- [x] **CI green** on this PR's own run (`lint` + `ci-build-test-checks`) — see checks below
- [x] **Self-reviewed diff** — 1 file changed, install step + helper only, no unrelated edits

**Note on `verify-publications` self-testing:** that workflow is `paths`-gated to `**/local/package.json` and `README.md`, so a workflow-only change does not trigger it (and even if triggered, its `changed-files` guard would skip the verify step with no server package.json changed). Its logic is therefore validated by the local simulation above rather than by a live run on this PR.